### PR TITLE
fix incredibly minor typo in OnePiece.Commanded README

### DIFF
--- a/apps/one_piece_commanded/README.md
+++ b/apps/one_piece_commanded/README.md
@@ -1,7 +1,6 @@
 # OnePiece.Commanded
 
-Extend `Commanded` package. A swiss army knife for applications following Domain-Driven Design (DDD), Event Sourcing (
-ES), and Command and Query Responsibility Segregation (CQRS).
+Extend `Commanded` package. A swiss army knife for applications following Domain-Driven Design (DDD), Event Sourcing (ES), and Command and Query Responsibility Segregation (CQRS).
 
 ## Documentation
 


### PR DESCRIPTION
Looks like some line-wrapping got inside of a parenthesis.  Markdown renders a space in there.  This unwraps the line so it formats correctly.