### PR TITLE
fix(trogon_typeprovider): improve struct detection for embedded schemas

### DIFF
--- a/apps/trogon_typeprovider/lib/trogon/type_provider.ex
+++ b/apps/trogon_typeprovider/lib/trogon/type_provider.ex
@@ -215,7 +215,10 @@ defmodule Trogon.TypeProvider do
   end
 
   defp defines_struct?(mod) do
-    function_exported?(mod, :__struct__, 0)
+    :functions
+    |> mod.__info__()
+    |> Keyword.get(:__struct__)
+    |> Kernel.!=(nil)
   end
 
   defp ensure_compiled!(mod) do


### PR DESCRIPTION
Replace function_exported? check with mod.__info__(:functions) to properly
detect structs during compilation. This fixes compatibility with Ecto's
embedded_schema macro which generates __struct__ functions that are not
available during macro expansion.

Signed-off-by: Yordis Prieto <yordis.prieto@gmail.com>
