### PR TITLE
fix(trogon_commanded): validate command and aggregate identity configuration in CommandHandlerCase

### DIFF
--- a/apps/trogon_commanded/lib/trogon/commanded/test_support/command_handler_case.ex
+++ b/apps/trogon_commanded/lib/trogon/commanded/test_support/command_handler_case.ex
@@ -50,6 +50,8 @@ defmodule Trogon.Commanded.TestSupport.CommandHandlerCase do
   use ExUnit.CaseTemplate
 
   alias Commanded.Aggregate.Multi
+  alias Commanded.Middleware.Pipeline
+  alias Commanded.Middleware.ExtractAggregateIdentity
   alias Trogon.Commanded.TestSupport.CommandHandlerCase
 
   using opts do
@@ -106,61 +108,38 @@ defmodule Trogon.Commanded.TestSupport.CommandHandlerCase do
     end
   end
 
-  def assert_events(
-        initial_events,
-        command,
-        expected_events,
-        aggregate_module,
-        command_handler_module
-      ) do
-    assert {:ok, _state, events} =
-             aggregate_run(
-               aggregate_module,
-               command_handler_module,
-               initial_events,
-               command
-             )
+  def assert_events(initial_events, command, expected_events, aggregate_module, command_handler_module) do
+    run_and_assert(initial_events, command, aggregate_module, command_handler_module, fn
+      {:ok, _state, events} ->
+        assert List.wrap(events) == List.wrap(expected_events)
 
-    actual_events = List.wrap(events)
-    expected_events = List.wrap(expected_events)
-
-    assert actual_events == expected_events
+      {:error, reason} ->
+        flunk("Expected success but got error: #{inspect(reason)}")
+    end)
   end
 
-  def assert_state(
-        initial_events,
-        command,
-        expected_state,
-        aggregate_module,
-        command_handler_module
-      ) do
-    assert {:ok, state, _events} =
-             aggregate_run(
-               aggregate_module,
-               command_handler_module,
-               initial_events,
-               command
-             )
+  def assert_state(initial_events, command, expected_state, aggregate_module, command_handler_module) do
+    run_and_assert(initial_events, command, aggregate_module, command_handler_module, fn
+      {:ok, state, _events} ->
+        assert state == expected_state
 
-    assert state == expected_state
+      {:error, reason} ->
+        flunk("Expected success but got error: #{inspect(reason)}")
+    end)
   end
 
-  def assert_error(
-        initial_events,
-        command,
-        expected_error,
-        aggregate_module,
-        command_handler_module
-      ) do
-    assert {:error, reason} =
-             aggregate_run(
-               aggregate_module,
-               command_handler_module,
-               initial_events,
-               command
-             )
+  def assert_error(initial_events, command, expected_error, aggregate_module, command_handler_module) do
+    run_and_assert(initial_events, command, aggregate_module, command_handler_module, fn
+      {:error, reason} -> assert reason == expected_error
+      {:ok, _state, _events} -> flunk("Expected error #{inspect(expected_error)}, but command succeeded")
+    end)
+  end
 
-    assert reason == expected_error
+  defp run_and_assert(initial_events, command, aggregate_module, command_handler_module, assertion_fn) do
+    assert is_list(initial_events), "Initial events must be a list of events"
+    validate_identity_configuration(command, aggregate_module)
+    result = aggregate_run(aggregate_module, command_handler_module, initial_events, command)
+    assertion_fn.(result)
   end
 
   defp aggregate_run(aggregate_module, command_handler_module, initial_events, command) do
@@ -237,5 +216,72 @@ defmodule Trogon.Commanded.TestSupport.CommandHandlerCase do
     events
     |> List.wrap()
     |> Enum.reduce(state, &evolver.(&2, &1))
+  end
+
+  defp validate_identity_configuration(command, aggregate_module) do
+    command_module = command.__struct__
+
+    command_has_identity? =
+      function_exported?(command_module, :aggregate_identifier, 0) and
+        function_exported?(command_module, :identity_prefix, 0)
+
+    aggregate_has_identity? =
+      function_exported?(aggregate_module, :identifier, 0) and
+        function_exported?(aggregate_module, :identity_prefix, 0)
+
+    if command_has_identity? and aggregate_has_identity? do
+      validate_identifier_match(command_module, aggregate_module)
+      validate_prefix_match(command_module, aggregate_module)
+      validate_aggregate_uuid_extraction(command, command_module)
+    else
+      :ok
+    end
+  end
+
+  defp validate_identifier_match(command_module, aggregate_module) do
+    command_identifier = command_module.aggregate_identifier()
+    aggregate_identifier = aggregate_module.identifier()
+
+    assert command_identifier == aggregate_identifier, """
+    Identity field mismatch between command and aggregate.
+
+    Command #{inspect(command_module)} uses #{inspect(command_identifier)}
+    Aggregate #{inspect(aggregate_module)} uses #{inspect(aggregate_identifier)}
+    """
+  end
+
+  defp validate_prefix_match(command_module, aggregate_module) do
+    command_prefix = command_module.identity_prefix()
+    aggregate_prefix = aggregate_module.identity_prefix()
+
+    assert command_prefix == aggregate_prefix, """
+    Identity prefix mismatch between command and aggregate.
+
+    Command #{inspect(command_module)} uses #{inspect(command_prefix)}
+    Aggregate #{inspect(aggregate_module)} uses #{inspect(aggregate_prefix)}
+    """
+  end
+
+  defp validate_aggregate_uuid_extraction(command, command_module) do
+    identifier = command_module.aggregate_identifier()
+    identity_prefix = command_module.identity_prefix()
+
+    pipeline =
+      %Pipeline{command: command, identity: identifier, identity_prefix: identity_prefix}
+      |> ExtractAggregateIdentity.before_dispatch()
+
+    case pipeline do
+      %Pipeline{assigns: %{aggregate_uuid: uuid}} when is_binary(uuid) and uuid != "" ->
+        :ok
+
+      _ ->
+        flunk("""
+        Failed to extract aggregate UUID from command.
+
+        Command: #{inspect(command)}
+        Identity field: #{inspect(identifier)}
+        Identity prefix: #{inspect(identity_prefix)}
+        """)
+    end
   end
 end

--- a/apps/trogon_commanded/test/trogon/commanded/test_support/command_handler_case_identity_test.exs
+++ b/apps/trogon_commanded/test/trogon/commanded/test_support/command_handler_case_identity_test.exs
@@ -1,0 +1,174 @@
+defmodule Trogon.Commanded.TestSupport.CommandHandlerCaseIdentityTest do
+  use ExUnit.Case, async: true
+
+  alias Trogon.Commanded.TestSupport.CommandHandlerCase
+
+  alias TestSupport.CommandHandlerCaseFixtures.{
+    TestAggregate,
+    TestCommand,
+    TestEvent
+  }
+
+  defmodule AccountCreated do
+    use Trogon.Commanded.Event, aggregate_identifier: :uuid
+
+    embedded_schema do
+      field :name, :string
+    end
+  end
+
+  defmodule CreateAccount do
+    use Trogon.Commanded.Command,
+      aggregate_identifier: :uuid,
+      identity_prefix: "account-"
+
+    embedded_schema do
+      field :name, :string
+    end
+  end
+
+  defmodule Account do
+    use Trogon.Commanded.Aggregate,
+      identifier: :uuid,
+      identity_prefix: "account-"
+
+    embedded_schema do
+      field :name, :string
+    end
+
+    def apply(aggregate, %AccountCreated{} = event) do
+      %{aggregate | uuid: event.uuid, name: event.name}
+    end
+
+    def execute(_aggregate, %CreateAccount{} = command) do
+      %AccountCreated{uuid: command.uuid, name: command.name}
+    end
+  end
+
+  defmodule MismatchedPrefixCommand do
+    use Trogon.Commanded.Command,
+      aggregate_identifier: :uuid,
+      identity_prefix: "wrong-prefix-"
+
+    embedded_schema do
+      field :name, :string
+    end
+  end
+
+  defmodule MismatchedFieldCommand do
+    use Trogon.Commanded.Command,
+      aggregate_identifier: :account_id,
+      identity_prefix: "account-"
+
+    embedded_schema do
+      field :name, :string
+    end
+  end
+
+  describe "identity configuration validation" do
+    test "passes when command and aggregate identity config match" do
+      CommandHandlerCase.assert_events(
+        [],
+        %CreateAccount{uuid: "test123", name: "Test Account"},
+        [%AccountCreated{uuid: "test123", name: "Test Account"}],
+        Account,
+        nil
+      )
+    end
+
+    test "passes state assertion when config matches" do
+      CommandHandlerCase.assert_state(
+        [],
+        %CreateAccount{uuid: "test123", name: "Test Account"},
+        %Account{uuid: "test123", name: "Test Account"},
+        Account,
+        nil
+      )
+    end
+
+    test "fails when identity prefix does not match" do
+      assert_raise ExUnit.AssertionError, ~r/Identity prefix mismatch/, fn ->
+        CommandHandlerCase.assert_events(
+          [],
+          %MismatchedPrefixCommand{uuid: "test123", name: "Test"},
+          [],
+          Account,
+          nil
+        )
+      end
+    end
+
+    test "fails when identity field does not match" do
+      assert_raise ExUnit.AssertionError, ~r/Identity field mismatch/, fn ->
+        CommandHandlerCase.assert_events(
+          [],
+          %MismatchedFieldCommand{account_id: "test123", name: "Test"},
+          [],
+          Account,
+          nil
+        )
+      end
+    end
+
+    test "fails when aggregate UUID cannot be extracted" do
+      assert_raise ExUnit.AssertionError, ~r/Failed to extract aggregate UUID/, fn ->
+        CommandHandlerCase.assert_events(
+          [],
+          %CreateAccount{uuid: nil, name: "Test"},
+          [],
+          Account,
+          nil
+        )
+      end
+    end
+
+    test "validates identity on assert_error path" do
+      assert_raise ExUnit.AssertionError, ~r/Identity prefix mismatch/, fn ->
+        CommandHandlerCase.assert_error(
+          [],
+          %MismatchedPrefixCommand{uuid: "test123", name: "Test"},
+          :some_error,
+          Account,
+          nil
+        )
+      end
+    end
+
+  end
+
+  defmodule PlainAggregate do
+    defstruct [:uuid, :name]
+
+    def apply(aggregate, %AccountCreated{} = event) do
+      %{aggregate | uuid: event.uuid, name: event.name}
+    end
+
+    def execute(_aggregate, %CreateAccount{} = command) do
+      %AccountCreated{uuid: command.uuid, name: command.name}
+    end
+  end
+
+  describe "skips validation when only one side has identity config" do
+    test "trogon command with plain struct aggregate" do
+      CommandHandlerCase.assert_events(
+        [],
+        %CreateAccount{uuid: "test123", name: "Test"},
+        [%AccountCreated{uuid: "test123", name: "Test"}],
+        PlainAggregate,
+        nil
+      )
+    end
+  end
+
+  describe "backward compatibility" do
+    test "neither side has identity config" do
+      CommandHandlerCase.assert_events(
+        [],
+        %TestCommand{id: "simple", action: :create_event},
+        [%TestEvent{id: "simple", name: "created"}],
+        TestAggregate,
+        nil
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `CommandHandlerCase` now validates that command and aggregate identity configuration match (field name and prefix) before running assertions
- Catches misconfigurations that previously went undetected: wrong prefix, wrong identifier field, and nil UUID extraction
- Validation only runs when **both** command and aggregate have identity config — plain struct aggregates (e.g., used with `register_transaction_script`) skip validation, matching production behavior
- No data transformation — events and state are compared as-is, matching real Commanded runtime behavior where the prefix only affects stream routing

## Test plan

- [x] Existing 26 `CommandHandlerCase` tests pass unchanged (backward compatible)
- [x] New tests: matching config passes, mismatched prefix fails, mismatched field fails, nil UUID extraction fails, assert_error path validates identity
- [x] Trogon command + plain struct aggregate skips validation
- [x] Neither side having identity config works unchanged