### PR TITLE
feat(trogon_exunit_reporter): add ExUnit reporter for AI agents

### DIFF
--- a/apps/trogon_exunit_reporter/.formatter.exs
+++ b/apps/trogon_exunit_reporter/.formatter.exs
@@ -1,0 +1,4 @@
+[
+  line_length: 120,
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/apps/trogon_exunit_reporter/.gitignore
+++ b/apps/trogon_exunit_reporter/.gitignore
@@ -1,0 +1,26 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+*.tar
+
+# Temporary files for e.g. tests
+/tmp

--- a/apps/trogon_exunit_reporter/CHANGELOG.md
+++ b/apps/trogon_exunit_reporter/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## v0.1.0
+
+- Initial release
+- JSONL output format for AI agent consumption
+- Smart verbose: minimal for passing tests, rich context for failures
+- Configurable output destination (file or stdout)

--- a/apps/trogon_exunit_reporter/LICENSE
+++ b/apps/trogon_exunit_reporter/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-Present Straw Hat, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/trogon_exunit_reporter/README.md
+++ b/apps/trogon_exunit_reporter/README.md
@@ -1,0 +1,84 @@
+# Trogon.ExunitReporter
+
+An ExUnit formatter that writes a token-optimized test report for AI coding agents.
+
+## Design Principles
+
+- **Silent on success** — passing tests produce zero output, only the summary line
+- **Dense on failure** — assertion code, left/right values, error message, trimmed stacktrace
+- **Runs alongside the CLI formatter** — humans see normal terminal output, agents read the file
+- **Plain text** — no JSON overhead, LLMs parse text natively
+
+## Installation
+
+Add `trogon_exunit_reporter` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:trogon_exunit_reporter, "~> 0.1.0", only: :test}
+  ]
+end
+```
+
+## Usage
+
+Add the reporter alongside the default CLI formatter in `test/test_helper.exs`:
+
+```elixir
+ExUnit.configure(
+  formatters: [ExUnit.CLIFormatter, Trogon.ExunitReporter]
+)
+
+ExUnit.start()
+```
+
+After running `mix test`, the agent reads `test-report.txt`.
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `file_path` | `String.t()` | `"test-report.txt"` | Output file path |
+| `include_logs` | `boolean()` | `true` | Include captured logs in failure output |
+
+```elixir
+ExUnit.configure(
+  formatters: [ExUnit.CLIFormatter, Trogon.ExunitReporter],
+  trogon_exunit_reporter: [
+    file_path: "test-report.txt",
+    include_logs: true
+  ]
+)
+```
+
+## Output Format
+
+When all tests pass — one line:
+
+```
+ALL PASSED | 42 tests, 42 passed | 150ms
+```
+
+When tests fail — only failures appear, followed by the summary:
+
+```
+FAIL test this assertion fails (ExampleFailingTest)
+  test/example_test.exs:19
+  ** (error)
+  message: Assertion with == failed
+  code:    assert [1, 2, 3] == [1, 2, 4]
+  left:    [1, 2, 3]
+  right:   [1, 2, 4]
+  stacktrace:
+    test/example_test.exs:20 ExampleFailingTest.test this assertion fails/1
+
+FAIL test runtime error (ExampleFailingTest)
+  test/example_test.exs:22
+  ** (error)
+  something broke
+  stacktrace:
+    test/example_test.exs:23 ExampleFailingTest.test runtime error/1
+
+FAILURES | 5 tests, 2 passed, 2 failed, 1 skipped | 5ms
+```

--- a/apps/trogon_exunit_reporter/README.md
+++ b/apps/trogon_exunit_reporter/README.md
@@ -1,4 +1,4 @@
-# Trogon.ExunitReporter
+# Trogon.ExUnitReporter
 
 An ExUnit formatter that writes a token-optimized test report for AI coding agents.
 
@@ -27,7 +27,7 @@ Add the reporter alongside the default CLI formatter in `test/test_helper.exs`:
 
 ```elixir
 ExUnit.configure(
-  formatters: [ExUnit.CLIFormatter, Trogon.ExunitReporter]
+  formatters: [ExUnit.CLIFormatter, Trogon.ExUnitReporter]
 )
 
 ExUnit.start()
@@ -44,7 +44,7 @@ After running `mix test`, the agent reads `test-report.txt`.
 
 ```elixir
 ExUnit.configure(
-  formatters: [ExUnit.CLIFormatter, Trogon.ExunitReporter],
+  formatters: [ExUnit.CLIFormatter, Trogon.ExUnitReporter],
   trogon_exunit_reporter: [
     file_path: "test-report.txt",
     include_logs: true
@@ -63,22 +63,17 @@ ALL PASSED | 42 tests, 42 passed | 150ms
 When tests fail — only failures appear, followed by the summary:
 
 ```
-FAIL test this assertion fails (ExampleFailingTest)
-  test/example_test.exs:19
-  ** (error)
-  message: Assertion with == failed
-  code:    assert [1, 2, 3] == [1, 2, 4]
-  left:    [1, 2, 3]
-  right:   [1, 2, 4]
-  stacktrace:
-    test/example_test.exs:20 ExampleFailingTest.test this assertion fails/1
+FAIL test comparison fails
+  test/example_test.exs:10
+  assert result == expected
+  left:  [1, 2, 3]
+  right: [1, 2, 4]
+  test/example_test.exs:11 ExampleFailingTest.test comparison fails/1
 
-FAIL test runtime error (ExampleFailingTest)
+FAIL test runtime error
   test/example_test.exs:22
-  ** (error)
   something broke
-  stacktrace:
-    test/example_test.exs:23 ExampleFailingTest.test runtime error/1
+  test/example_test.exs:23 ExampleFailingTest.test runtime error/1
 
-FAILURES | 5 tests, 2 passed, 2 failed, 1 skipped | 5ms
+FAILURES | 5 tests, 3 passed, 2 failed | 5ms
 ```

--- a/apps/trogon_exunit_reporter/coveralls.json
+++ b/apps/trogon_exunit_reporter/coveralls.json
@@ -1,0 +1,5 @@
+{
+  "coverage_options": {
+    "treat_no_relevant_lines_as_covered": true
+  }
+}

--- a/apps/trogon_exunit_reporter/lib/trogon/exunit_reporter.ex
+++ b/apps/trogon_exunit_reporter/lib/trogon/exunit_reporter.ex
@@ -1,0 +1,120 @@
+defmodule Trogon.ExunitReporter do
+  @moduledoc """
+  An ExUnit formatter that writes a token-optimized test report to a file.
+
+  Designed for AI coding agents. Passing tests produce zero output — only the
+  summary line. Failed tests get compact but complete diagnostic blocks with
+  assertion details, diffs, and trimmed stacktraces.
+
+  Runs alongside the default CLI formatter: humans see normal terminal output,
+  the agent reads the report file.
+
+  ## Usage
+
+  Add this formatter in your `test/test_helper.exs`:
+
+      ExUnit.configure(
+        formatters: [ExUnit.CLIFormatter, Trogon.ExunitReporter]
+      )
+
+      ExUnit.start()
+
+  ## Configuration
+
+  Pass options under the `:trogon_exunit_reporter` key:
+
+      ExUnit.configure(
+        formatters: [ExUnit.CLIFormatter, Trogon.ExunitReporter],
+        trogon_exunit_reporter: [
+          file_path: "test-report.txt",
+          include_logs: true
+        ]
+      )
+
+  See `Trogon.ExunitReporter.Config` for all available options.
+  """
+
+  use GenServer
+
+  alias Trogon.ExunitReporter.Config
+  alias Trogon.ExunitReporter.Event
+
+  defstruct [:config, :io_device, :counters]
+
+  @type t :: %__MODULE__{
+          config: Config.t(),
+          io_device: File.io_device(),
+          counters: map()
+        }
+
+  @impl GenServer
+  def init(opts) do
+    config = Config.from_exunit_opts!(opts)
+    io_device = open_file(config.file_path)
+
+    state = %__MODULE__{
+      config: config,
+      io_device: io_device,
+      counters: %{total: 0, passed: 0, failed: 0, skipped: 0, excluded: 0, invalid: 0}
+    }
+
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_cast({:suite_started, _opts}, state) do
+    {:noreply, state}
+  end
+
+  def handle_cast({:test_finished, %ExUnit.Test{} = test}, state) do
+    event_opts = [include_logs: state.config.include_logs]
+
+    case Event.format_test(test, event_opts) do
+      nil -> :ok
+      iodata -> IO.write(state.io_device, [iodata, "\n"])
+    end
+
+    counters = update_counters(state.counters, test)
+    {:noreply, %{state | counters: counters}}
+  end
+
+  def handle_cast({:suite_finished, times_us}, state) do
+    IO.write(state.io_device, Event.format_summary(times_us, state.counters))
+    File.close(state.io_device)
+    {:noreply, state}
+  end
+
+  def handle_cast(:max_failures_reached, state) do
+    IO.write(state.io_device, Event.format_max_failures_reached())
+    {:noreply, state}
+  end
+
+  def handle_cast({:sigquit, _running}, state) do
+    File.close(state.io_device)
+    {:noreply, state}
+  end
+
+  def handle_cast(_event, state), do: {:noreply, state}
+
+  # -- Private --
+
+  defp update_counters(counters, %ExUnit.Test{state: state}) do
+    key =
+      case state do
+        nil -> :passed
+        {:failed, _} -> :failed
+        {:skipped, _} -> :skipped
+        {:excluded, _} -> :excluded
+        {:invalid, _} -> :invalid
+      end
+
+    counters
+    |> Map.update!(:total, &(&1 + 1))
+    |> Map.update!(key, &(&1 + 1))
+  end
+
+  defp open_file(path) do
+    path |> Path.dirname() |> File.mkdir_p!()
+    File.open!(path, [:write, :utf8])
+  end
+end

--- a/apps/trogon_exunit_reporter/lib/trogon/exunit_reporter.ex
+++ b/apps/trogon_exunit_reporter/lib/trogon/exunit_reporter.ex
@@ -1,4 +1,4 @@
-defmodule Trogon.ExunitReporter do
+defmodule Trogon.ExUnitReporter do
   @moduledoc """
   An ExUnit formatter that writes a token-optimized test report to a file.
 
@@ -14,7 +14,7 @@ defmodule Trogon.ExunitReporter do
   Add this formatter in your `test/test_helper.exs`:
 
       ExUnit.configure(
-        formatters: [ExUnit.CLIFormatter, Trogon.ExunitReporter]
+        formatters: [ExUnit.CLIFormatter, Trogon.ExUnitReporter]
       )
 
       ExUnit.start()
@@ -24,20 +24,20 @@ defmodule Trogon.ExunitReporter do
   Pass options under the `:trogon_exunit_reporter` key:
 
       ExUnit.configure(
-        formatters: [ExUnit.CLIFormatter, Trogon.ExunitReporter],
+        formatters: [ExUnit.CLIFormatter, Trogon.ExUnitReporter],
         trogon_exunit_reporter: [
           file_path: "test-report.txt",
           include_logs: true
         ]
       )
 
-  See `Trogon.ExunitReporter.Config` for all available options.
+  See `Trogon.ExUnitReporter.Config` for all available options.
   """
 
   use GenServer
 
-  alias Trogon.ExunitReporter.Config
-  alias Trogon.ExunitReporter.Event
+  alias Trogon.ExUnitReporter.Config
+  alias Trogon.ExUnitReporter.Event
 
   defstruct [:config, :io_device, :counters]
 

--- a/apps/trogon_exunit_reporter/lib/trogon/exunit_reporter/config.ex
+++ b/apps/trogon_exunit_reporter/lib/trogon/exunit_reporter/config.ex
@@ -1,0 +1,52 @@
+defmodule Trogon.ExunitReporter.Config do
+  @moduledoc """
+  Configuration parsing and validation for the ExUnit AI agent reporter.
+  """
+
+  @schema NimbleOptions.new!(
+            file_path: [
+              type: :string,
+              default: "test-report.txt",
+              doc: "File path for the test report."
+            ],
+            include_logs: [
+              type: :boolean,
+              default: true,
+              doc: "Whether to include captured log output in failure details."
+            ]
+          )
+
+  @type t :: %__MODULE__{
+          file_path: String.t(),
+          include_logs: boolean()
+        }
+
+  @enforce_keys [:file_path, :include_logs]
+  defstruct [:file_path, :include_logs]
+
+  @doc """
+  Builds a `%Config{}` from the ExUnit options map.
+
+  Extracts the `:trogon_exunit_reporter` key, validates it against the schema,
+  and returns a config struct.
+  """
+  @spec from_exunit_opts(keyword()) :: {:ok, t()} | {:error, NimbleOptions.ValidationError.t()}
+  def from_exunit_opts(exunit_opts) do
+    opts = Keyword.get(exunit_opts, :trogon_exunit_reporter, [])
+
+    case NimbleOptions.validate(opts, @schema) do
+      {:ok, validated} -> {:ok, struct!(__MODULE__, validated)}
+      {:error, _} = error -> error
+    end
+  end
+
+  @doc """
+  Same as `from_exunit_opts/1` but raises on invalid configuration.
+  """
+  @spec from_exunit_opts!(keyword()) :: t()
+  def from_exunit_opts!(exunit_opts) do
+    opts = Keyword.get(exunit_opts, :trogon_exunit_reporter, [])
+    validated = NimbleOptions.validate!(opts, @schema)
+    struct!(__MODULE__, validated)
+  end
+end

--- a/apps/trogon_exunit_reporter/lib/trogon/exunit_reporter/config.ex
+++ b/apps/trogon_exunit_reporter/lib/trogon/exunit_reporter/config.ex
@@ -1,4 +1,4 @@
-defmodule Trogon.ExunitReporter.Config do
+defmodule Trogon.ExUnitReporter.Config do
   @moduledoc """
   Configuration parsing and validation for the ExUnit AI agent reporter.
   """

--- a/apps/trogon_exunit_reporter/lib/trogon/exunit_reporter/event.ex
+++ b/apps/trogon_exunit_reporter/lib/trogon/exunit_reporter/event.ex
@@ -1,4 +1,4 @@
-defmodule Trogon.ExunitReporter.Event do
+defmodule Trogon.ExUnitReporter.Event do
   @moduledoc """
   Formats ExUnit events as compact plain text optimized for AI agent token consumption.
 

--- a/apps/trogon_exunit_reporter/lib/trogon/exunit_reporter/event.ex
+++ b/apps/trogon_exunit_reporter/lib/trogon/exunit_reporter/event.ex
@@ -1,0 +1,177 @@
+defmodule Trogon.ExunitReporter.Event do
+  @moduledoc """
+  Formats ExUnit events as compact plain text optimized for AI agent token consumption.
+
+  Only failures produce detailed output. Passing tests are counted but not listed.
+  """
+
+  @doc """
+  Formats a failed `%ExUnit.Test{}` as a compact text block.
+
+  Returns `nil` for non-failed tests (they only contribute to counters).
+  """
+  @spec format_test(ExUnit.Test.t(), keyword()) :: iodata() | nil
+  def format_test(%ExUnit.Test{state: {:failed, failures}} = test, opts) do
+    header = "FAIL #{test.name}"
+    location = "  #{test.tags[:file]}:#{test.tags[:line]}"
+
+    failure_lines =
+      failures
+      |> Enum.with_index(1)
+      |> Enum.map(fn {failure, idx} ->
+        format_failure(failure, idx, length(failures))
+      end)
+
+    logs = format_logs(test, opts)
+
+    [header, "\n", location, "\n" | failure_lines] ++ logs
+  end
+
+  def format_test(_test, _opts), do: nil
+
+  @doc """
+  Formats the suite summary as a single dense line.
+
+  When all tests pass, this is the only output — one line an agent can read
+  and immediately stop processing.
+  """
+  @spec format_summary(map(), map()) :: iodata()
+  def format_summary(times_us, counters) do
+    run_ms = div(times_us.run, 1000)
+
+    status =
+      if counters.failed == 0 and counters.invalid == 0,
+        do: "ALL PASSED",
+        else: "FAILURES"
+
+    parts =
+      [
+        "#{counters.total} tests",
+        "#{counters.passed} passed",
+        if(counters.failed > 0, do: "#{counters.failed} failed"),
+        if(counters.skipped > 0, do: "#{counters.skipped} skipped"),
+        if(counters.excluded > 0, do: "#{counters.excluded} excluded"),
+        if(counters.invalid > 0, do: "#{counters.invalid} invalid")
+      ]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join(", ")
+
+    [status, " | ", parts, " | #{run_ms}ms\n"]
+  end
+
+  @doc """
+  Formats the max failures reached marker.
+  """
+  @spec format_max_failures_reached() :: iodata()
+  def format_max_failures_reached do
+    ["MAX FAILURES REACHED\n"]
+  end
+
+  # -- Private helpers --
+
+  defp format_failure({_kind, reason, stacktrace}, idx, total) do
+    prefix = if total > 1, do: "  [#{idx}/#{total}] ", else: ""
+
+    lines =
+      case reason do
+        %ExUnit.AssertionError{} = err ->
+          [prefix]
+          |> append_if(err.expr, "  #{format_expr(err.expr)}\n")
+          |> append_left_right(err)
+
+        %{__exception__: true} = err ->
+          [prefix, "  ", Exception.message(err), "\n"]
+
+        other ->
+          [prefix, "  ", inspect(other), "\n"]
+      end
+
+    case format_stacktrace(stacktrace) do
+      [] -> lines
+      frames -> lines ++ Enum.map(frames, &["  ", &1, "\n"])
+    end
+  end
+
+  defp format_expr(nil), do: nil
+
+  defp format_expr(expr) do
+    Macro.to_string(expr)
+  rescue
+    _ -> inspect(expr)
+  end
+
+  defp format_value(:ex_unit_no_meaningful_value), do: nil
+  defp format_value(value), do: inspect(value, pretty: true, limit: 50)
+
+  defp append_if(lines, nil, _text), do: lines
+  defp append_if(lines, _value, text), do: lines ++ [text]
+
+  defp append_left_right(lines, %ExUnit.AssertionError{} = err) do
+    left = format_value(err.left)
+    right = format_value(err.right)
+    expr_str = format_expr(err.expr)
+
+    lines
+    |> append_if_novel(left, "  left:  #{left}\n", expr_str)
+    |> append_if_novel(right, "  right: #{right}\n", expr_str)
+  end
+
+  defp append_if_novel(lines, nil, _text, _expr_str), do: lines
+
+  defp append_if_novel(lines, _value, text, nil), do: lines ++ [text]
+
+  defp append_if_novel(lines, value, text, expr_str) do
+    if String.contains?(expr_str, value) do
+      lines
+    else
+      lines ++ [text]
+    end
+  end
+
+  defp format_stacktrace(stacktrace) when is_list(stacktrace) do
+    stacktrace
+    |> Enum.reject(&internal_frame?/1)
+    |> Enum.map(&format_frame/1)
+  end
+
+  defp format_stacktrace(_), do: []
+
+  defp format_frame({mod, fun, arity, location}) do
+    file = Keyword.get(location, :file, ~c"nofile") |> to_string()
+    line = Keyword.get(location, :line, 0)
+    "#{file}:#{line} #{inspect(mod)}.#{fun}/#{arity_value(arity)}"
+  end
+
+  defp format_frame(other), do: inspect(other)
+
+  defp arity_value(args) when is_list(args), do: length(args)
+  defp arity_value(n) when is_integer(n), do: n
+
+  @internal_modules [ExUnit, ExUnit.Runner, ExUnit.Assertions]
+
+  defp internal_frame?({mod, _fun, _arity, _location}) do
+    mod_string = Atom.to_string(mod)
+
+    Enum.any?(@internal_modules, fn internal ->
+      String.starts_with?(mod_string, Atom.to_string(internal))
+    end)
+  end
+
+  defp internal_frame?(_), do: false
+
+  defp format_logs(%ExUnit.Test{logs: logs}, opts) when is_binary(logs) and logs != "" do
+    if Keyword.get(opts, :include_logs, true) do
+      indent_lines(logs, "  ")
+    else
+      []
+    end
+  end
+
+  defp format_logs(_test, _opts), do: []
+
+  defp indent_lines(text, prefix) do
+    text
+    |> String.split("\n", trim: true)
+    |> Enum.map(&[prefix, &1, "\n"])
+  end
+end

--- a/apps/trogon_exunit_reporter/mix.exs
+++ b/apps/trogon_exunit_reporter/mix.exs
@@ -1,4 +1,4 @@
-defmodule Trogon.ExunitReporter.MixProject do
+defmodule Trogon.ExUnitReporter.MixProject do
   use Mix.Project
 
   @app :trogon_exunit_reporter
@@ -12,8 +12,8 @@ defmodule Trogon.ExunitReporter.MixProject do
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
-      name: "Trogon.ExunitReporter",
-      description: "An ExUnit formatter that produces JSONL output optimized for AI agent consumption",
+      name: "Trogon.ExUnitReporter",
+      description: "An ExUnit formatter that writes a token-optimized test report for AI coding agents",
       app: @app,
       version: @version,
       elixir: @elixir_version,

--- a/apps/trogon_exunit_reporter/mix.exs
+++ b/apps/trogon_exunit_reporter/mix.exs
@@ -1,0 +1,115 @@
+defmodule Trogon.ExunitReporter.MixProject do
+  use Mix.Project
+
+  @app :trogon_exunit_reporter
+  @version "0.1.0"
+  @elixir_version "~> 1.13"
+  @source_url "https://github.com/straw-hat-team/beam-monorepo"
+
+  def project do
+    [
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      name: "Trogon.ExunitReporter",
+      description: "An ExUnit formatter that produces JSONL output optimized for AI agent consumption",
+      app: @app,
+      version: @version,
+      elixir: @elixir_version,
+      elixirc_paths: elixirc_paths(Mix.env()),
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      aliases: aliases(),
+      test_coverage: test_coverage(),
+      package: package(),
+      docs: docs(),
+      dialyzer: dialyzer()
+    ]
+  end
+
+  def cli do
+    [preferred_envs: preferred_cli_env()]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:nimble_options, "~> 1.0"},
+
+      # Tools
+      {:dialyxir, ">= 0.0.0", only: [:dev], runtime: false},
+      {:credo, ">= 0.0.0", only: [:dev, :test], runtime: false},
+      {:excoveralls, ">= 0.0.0", only: [:test], runtime: false},
+      {:ex_doc, ">= 0.0.0", only: [:dev], runtime: false}
+    ]
+  end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
+  defp aliases do
+    [
+      test: ["test --trace"]
+    ]
+  end
+
+  defp test_coverage do
+    [tool: ExCoveralls]
+  end
+
+  defp preferred_cli_env do
+    [
+      "coveralls.html": :test,
+      "coveralls.json": :test,
+      coveralls: :test
+    ]
+  end
+
+  defp dialyzer do
+    [
+      plt_core_path: "priv/plts"
+    ]
+  end
+
+  defp package do
+    [
+      name: @app,
+      files: [
+        ".formatter.exs",
+        "lib",
+        "mix.exs",
+        "README*",
+        "LICENSE*"
+      ],
+      maintainers: ["Yordis Prieto"],
+      licenses: ["MIT"],
+      links: %{
+        "GitHub" => @source_url
+      }
+    ]
+  end
+
+  defp docs do
+    [
+      main: "readme",
+      homepage_url: @source_url,
+      source_url_pattern: "#{@source_url}/blob/#{@app}@v#{@version}/apps/#{@app}/%{path}#L%{line}",
+      extras: [
+        "README.md",
+        "CHANGELOG.md"
+      ],
+      skip_undefined_reference_warnings_on: ["CHANGELOG.md"],
+      groups_for_extras: [
+        "How-to": ~r/docs\/how-to\/.?/,
+        Explanations: ~r/docs\/explanations\/.?/,
+        References: ~r/docs\/references\/.?/
+      ]
+    ]
+  end
+end

--- a/apps/trogon_exunit_reporter/test/test_helper.exs
+++ b/apps/trogon_exunit_reporter/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/apps/trogon_exunit_reporter/test/trogon/exunit_reporter/config_test.exs
+++ b/apps/trogon_exunit_reporter/test/trogon/exunit_reporter/config_test.exs
@@ -1,0 +1,47 @@
+defmodule Trogon.ExunitReporter.ConfigTest do
+  use ExUnit.Case, async: true
+
+  alias Trogon.ExunitReporter.Config
+
+  describe "from_exunit_opts/1" do
+    test "returns defaults when no options given" do
+      assert {:ok, config} = Config.from_exunit_opts([])
+      assert config.file_path == "test-report.txt"
+      assert config.include_logs == true
+    end
+
+    test "accepts valid custom options" do
+      opts = [
+        trogon_exunit_reporter: [
+          file_path: "custom-report.txt",
+          include_logs: false
+        ]
+      ]
+
+      assert {:ok, config} = Config.from_exunit_opts(opts)
+      assert config.file_path == "custom-report.txt"
+      assert config.include_logs == false
+    end
+
+    test "returns error for invalid file_path type" do
+      opts = [trogon_exunit_reporter: [file_path: 123]]
+      assert {:error, %NimbleOptions.ValidationError{}} = Config.from_exunit_opts(opts)
+    end
+  end
+
+  describe "from_exunit_opts!/1" do
+    test "returns config struct with defaults" do
+      config = Config.from_exunit_opts!([])
+      assert %Config{} = config
+      assert config.file_path == "test-report.txt"
+    end
+
+    test "raises on invalid options" do
+      opts = [trogon_exunit_reporter: [file_path: 123]]
+
+      assert_raise NimbleOptions.ValidationError, fn ->
+        Config.from_exunit_opts!(opts)
+      end
+    end
+  end
+end

--- a/apps/trogon_exunit_reporter/test/trogon/exunit_reporter/config_test.exs
+++ b/apps/trogon_exunit_reporter/test/trogon/exunit_reporter/config_test.exs
@@ -1,7 +1,7 @@
-defmodule Trogon.ExunitReporter.ConfigTest do
+defmodule Trogon.ExUnitReporter.ConfigTest do
   use ExUnit.Case, async: true
 
-  alias Trogon.ExunitReporter.Config
+  alias Trogon.ExUnitReporter.Config
 
   describe "from_exunit_opts/1" do
     test "returns defaults when no options given" do

--- a/apps/trogon_exunit_reporter/test/trogon/exunit_reporter_test.exs
+++ b/apps/trogon_exunit_reporter/test/trogon/exunit_reporter_test.exs
@@ -1,0 +1,286 @@
+defmodule Trogon.ExunitReporterTest do
+  use ExUnit.Case, async: true
+
+  alias Trogon.ExunitReporter
+
+  describe "passing tests produce no output" do
+    @tag :tmp_dir
+    test "only summary appears when all tests pass", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "report.txt")
+      pid = start_reporter(file_path)
+
+      cast_test(pid, :passing)
+      cast_test(pid, :passing)
+      finish_suite(pid)
+
+      output = read_report(file_path)
+      assert output =~ "ALL PASSED"
+      assert output =~ "2 tests, 2 passed"
+      refute output =~ "FAIL"
+    end
+  end
+
+  describe "failing tests produce diagnostic output" do
+    @tag :tmp_dir
+    test "includes assertion details for failed test", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "report.txt")
+      pid = start_reporter(file_path)
+
+      assertion_error = %ExUnit.AssertionError{
+        message: "Assertion with == failed",
+        expr: quote(do: assert(1 == 2)),
+        left: 1,
+        right: 2
+      }
+
+      cast_test(pid, {:failed, assertion_error, "test/math_test.exs", 11})
+      finish_suite(pid)
+
+      output = read_report(file_path)
+      assert output =~ "FAIL"
+      assert output =~ "assert 1 == 2"
+      refute output =~ "left:"
+      refute output =~ "right:"
+      assert output =~ "FAILURES"
+      assert output =~ "1 failed"
+    end
+
+    @tag :tmp_dir
+    test "includes left/right when expression uses variables", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "report.txt")
+      pid = start_reporter(file_path)
+
+      assertion_error = %ExUnit.AssertionError{
+        message: "Assertion with == failed",
+        expr: quote(do: assert(result == expected)),
+        left: [1, 2, 3],
+        right: [1, 2, 4]
+      }
+
+      cast_test(pid, {:failed, assertion_error, "test/var_test.exs", 5})
+      finish_suite(pid)
+
+      output = read_report(file_path)
+      assert output =~ "assert result == expected"
+      assert output =~ "left:"
+      assert output =~ "[1, 2, 3]"
+      assert output =~ "right:"
+      assert output =~ "[1, 2, 4]"
+    end
+
+    @tag :tmp_dir
+    test "includes runtime error details", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "report.txt")
+      pid = start_reporter(file_path)
+
+      cast_test(pid, {:failed, %RuntimeError{message: "boom"}, "test/boom_test.exs", 5})
+      finish_suite(pid)
+
+      output = read_report(file_path)
+      assert output =~ "FAIL"
+      assert output =~ "boom"
+    end
+
+    @tag :tmp_dir
+    test "includes stacktrace with internal frames filtered", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "report.txt")
+      pid = start_reporter(file_path)
+
+      stacktrace = [
+        {MyApp.MathTest, :"test math works", 1, [file: ~c"test/math_test.exs", line: 11]},
+        {ExUnit.Assertions, :assert, 1, [file: ~c"lib/ex_unit/assertions.ex", line: 100]}
+      ]
+
+      test_struct = %ExUnit.Test{
+        name: :"test math works",
+        module: MyApp.MathTest,
+        state: {:failed, [{:error, %RuntimeError{message: "oops"}, stacktrace}]},
+        time: 456,
+        tags: %{file: "test/math_test.exs", line: 10},
+        logs: ""
+      }
+
+      GenServer.cast(pid, {:test_finished, test_struct})
+      finish_suite(pid)
+
+      output = read_report(file_path)
+      assert output =~ "test/math_test.exs:11"
+      refute output =~ "assertions.ex"
+    end
+
+    @tag :tmp_dir
+    test "includes captured logs when configured", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "report.txt")
+      pid = start_reporter(file_path)
+
+      test_struct = %ExUnit.Test{
+        name: :"test with logs",
+        module: MyApp.LogTest,
+        state: {:failed, [{:error, %RuntimeError{message: "boom"}, []}]},
+        time: 100,
+        tags: %{file: "test/log_test.exs", line: 1},
+        logs: "[warning] something went wrong\n"
+      }
+
+      GenServer.cast(pid, {:test_finished, test_struct})
+      finish_suite(pid)
+
+      output = read_report(file_path)
+      assert output =~ "something went wrong"
+    end
+
+    @tag :tmp_dir
+    test "excludes logs when include_logs is false", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "report.txt")
+      pid = start_reporter(file_path, include_logs: false)
+
+      test_struct = %ExUnit.Test{
+        name: :"test with logs",
+        module: MyApp.LogTest,
+        state: {:failed, [{:error, %RuntimeError{message: "boom"}, []}]},
+        time: 100,
+        tags: %{file: "test/log_test.exs", line: 1},
+        logs: "[warning] something went wrong\n"
+      }
+
+      GenServer.cast(pid, {:test_finished, test_struct})
+      finish_suite(pid)
+
+      output = read_report(file_path)
+      refute output =~ "something went wrong"
+    end
+  end
+
+  describe "skipped and excluded tests" do
+    @tag :tmp_dir
+    test "counted in summary but produce no output lines", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "report.txt")
+      pid = start_reporter(file_path)
+
+      skipped = %ExUnit.Test{
+        name: :"test skipped",
+        module: MyApp.SkipTest,
+        state: {:skipped, "not implemented"},
+        time: 0,
+        tags: %{file: "test/skip_test.exs", line: 1},
+        logs: ""
+      }
+
+      excluded = %ExUnit.Test{
+        name: :"test excluded",
+        module: MyApp.ExcludeTest,
+        state: {:excluded, "excluded by tag"},
+        time: 0,
+        tags: %{file: "test/exclude_test.exs", line: 1},
+        logs: ""
+      }
+
+      GenServer.cast(pid, {:test_finished, skipped})
+      GenServer.cast(pid, {:test_finished, excluded})
+      finish_suite(pid)
+
+      output = read_report(file_path)
+      refute output =~ "FAIL"
+      assert output =~ "1 skipped"
+      assert output =~ "1 excluded"
+      assert output =~ "2 tests"
+    end
+  end
+
+  describe "summary line" do
+    @tag :tmp_dir
+    test "shows timing in milliseconds", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "report.txt")
+      pid = start_reporter(file_path)
+
+      cast_test(pid, :passing)
+      GenServer.cast(pid, {:suite_finished, %{run: 150_000, load: nil, async: nil}})
+      Process.sleep(20)
+
+      output = read_report(file_path)
+      assert output =~ "150ms"
+    end
+  end
+
+  describe "max_failures_reached" do
+    @tag :tmp_dir
+    test "writes marker to report", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "report.txt")
+      pid = start_reporter(file_path)
+
+      GenServer.cast(pid, :max_failures_reached)
+      finish_suite(pid)
+
+      output = read_report(file_path)
+      assert output =~ "MAX FAILURES REACHED"
+    end
+  end
+
+  describe "mixed pass and fail" do
+    @tag :tmp_dir
+    test "only failures appear, summary reflects all", %{tmp_dir: tmp_dir} do
+      file_path = Path.join(tmp_dir, "report.txt")
+      pid = start_reporter(file_path)
+
+      cast_test(pid, :passing)
+      cast_test(pid, :passing)
+      cast_test(pid, {:failed, %RuntimeError{message: "oops"}, "test/fail_test.exs", 10})
+      finish_suite(pid)
+
+      output = read_report(file_path)
+
+      lines = String.split(output, "\n", trim: true)
+      fail_lines = Enum.filter(lines, &String.starts_with?(&1, "FAIL "))
+      assert length(fail_lines) == 1
+
+      assert output =~ "3 tests, 2 passed, 1 failed"
+    end
+  end
+
+  # -- Test helpers --
+
+  defp start_reporter(file_path, extra_opts \\ []) do
+    opts = [
+      seed: 42,
+      trogon_exunit_reporter: Keyword.merge([file_path: file_path], extra_opts)
+    ]
+
+    {:ok, pid} = GenServer.start_link(ExunitReporter, opts)
+    pid
+  end
+
+  defp cast_test(pid, :passing) do
+    test_struct = %ExUnit.Test{
+      name: :"test passes",
+      module: MyApp.Test,
+      state: nil,
+      time: 100,
+      tags: %{file: "test/my_test.exs", line: 1},
+      logs: ""
+    }
+
+    GenServer.cast(pid, {:test_finished, test_struct})
+  end
+
+  defp cast_test(pid, {:failed, reason, file, line}) do
+    test_struct = %ExUnit.Test{
+      name: :"test fails",
+      module: MyApp.Test,
+      state: {:failed, [{:error, reason, []}]},
+      time: 200,
+      tags: %{file: file, line: line},
+      logs: ""
+    }
+
+    GenServer.cast(pid, {:test_finished, test_struct})
+  end
+
+  defp finish_suite(pid) do
+    GenServer.cast(pid, {:suite_finished, %{run: 5000, load: nil, async: nil}})
+    Process.sleep(20)
+  end
+
+  defp read_report(file_path) do
+    File.read!(file_path)
+  end
+end

--- a/apps/trogon_exunit_reporter/test/trogon/exunit_reporter_test.exs
+++ b/apps/trogon_exunit_reporter/test/trogon/exunit_reporter_test.exs
@@ -1,7 +1,7 @@
-defmodule Trogon.ExunitReporterTest do
+defmodule Trogon.ExUnitReporterTest do
   use ExUnit.Case, async: true
 
-  alias Trogon.ExunitReporter
+  alias Trogon.ExUnitReporter
 
   describe "passing tests produce no output" do
     @tag :tmp_dir
@@ -245,7 +245,7 @@ defmodule Trogon.ExunitReporterTest do
       trogon_exunit_reporter: Keyword.merge([file_path: file_path], extra_opts)
     ]
 
-    {:ok, pid} = GenServer.start_link(ExunitReporter, opts)
+    {:ok, pid} = GenServer.start_link(ExUnitReporter, opts)
     pid
   end
 


### PR DESCRIPTION
## Summary

- New umbrella app `trogon_exunit_reporter` — an ExUnit formatter that writes a token-optimized plain-text test report to a file, designed for AI coding agents
- Runs alongside the default CLI formatter: humans see normal terminal output, agents read `test-report.txt`
- Silent on success (only a summary line), dense on failure (assertion expression, left/right diffs only when novel, trimmed stacktraces, captured logs)

## Design decisions

Every token in the output was evaluated for whether it helps an AI agent fix a failing test:

- **No JSON** — plain text is cheaper on tokens and LLMs parse it natively
- **No output for passing tests** — zero tokens wasted on things that work
- **No redundant labels** — `code:`, `stacktrace:`, `logs:` labels removed; the format is self-evident
- **No exception kind** — `** (error)` is almost always error, not actionable
- **No module name in header** — file path and stacktrace already carry it
- **Smart left/right** — only included when the assertion expression uses variables; omitted when literal values are already visible in the expression

## Example output

All passing:
```
ALL PASSED | 42 tests, 42 passed | 150ms
```

With failures:
```
FAIL test this assertion fails
  test/example_test.exs:19
  assert [1, 2, 3] == [1, 2, 4]
  test/example_test.exs:20 ExampleFailingTest.test this assertion fails/1

FAIL test comparison fails
  test/example_test.exs:25
  assert result == expected
  left:  [1, 2, 3]
  right: [1, 2, 4]
  test/example_test.exs:26 ExampleFailingTest.test comparison fails/1

FAILURES | 5 tests, 3 passed, 2 failed | 5ms
```

## Test plan

- [x] 16 tests covering: passing tests (silent), assertion failures with literals and variables, runtime errors, stacktrace filtering, captured logs, log exclusion, skipped/excluded tests, summary line, max failures, file output, mixed pass/fail
- [x] `mix compile --warnings-as-errors` — 0 warnings
- [x] `mix credo --strict` — 0 issues