### PR TITLE
fix: make Process module configurable in ConsistencyPolicy

### DIFF
--- a/apps/trogon_commanded/lib/trogon/commanded/consistency_policy.ex
+++ b/apps/trogon_commanded/lib/trogon/commanded/consistency_policy.ex
@@ -47,6 +47,8 @@ defmodule Trogon.Commanded.ConsistencyPolicy do
     VersionMismatchError
   }
 
+  @process_mod Application.compile_env(:trogon_commanded, [__MODULE__, :process_module], Process)
+
   @typedoc "Event stream version (projection position)."
   @type version :: non_neg_integer()
 
@@ -181,7 +183,7 @@ defmodule Trogon.Commanded.ConsistencyPolicy do
        )}
     else
       remaining_ms = max(deadline - now, 0)
-      Process.sleep(min(delay_ms, remaining_ms))
+      @process_mod.sleep(min(delay_ms, remaining_ms))
       do_retry(policy, callback_fn, deadline, start_time, delay_ms, attempt + 1)
     end
   end


### PR DESCRIPTION
Allows configuring the Process module at compile time for testing.

Defaults to `Process` module but can be overridden via:

```elixir
config :trogon_commanded, Trogon.Commanded.ConsistencyPolicy,
  process_module: MyApp.MockProcess
```