### PR TITLE
ci: add hex-publish-docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,15 +10,6 @@ jobs:
   publish-docs:
     name: Publish Docs to Hex.pm
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        package-name:
-          - one_piece_graceful_shutdown
-          - trogon_commanded
-          - trogon_error
-          - trogon_proto
-          - trogon_result
-          - trogon_typeprovider
     steps:
       - uses: actions/checkout@v6
       - uses: 1password/load-secrets-action@v4
@@ -30,4 +21,20 @@ jobs:
       - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@master
         with:
           hex-api-key: ${{ env.HEX_API_KEY }}
-          package-name: ${{ matrix.package-name }}
+          package-name: trogon_commanded
+      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@master
+        with:
+          hex-api-key: ${{ env.HEX_API_KEY }}
+          package-name: trogon_error
+      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@master
+        with:
+          hex-api-key: ${{ env.HEX_API_KEY }}
+          package-name: trogon_proto
+      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@master
+        with:
+          hex-api-key: ${{ env.HEX_API_KEY }}
+          package-name: trogon_result
+      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@master
+        with:
+          hex-api-key: ${{ env.HEX_API_KEY }}
+          package-name: trogon_typeprovider

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,38 @@
+name: hex-publish-docs
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      hex-api-key: ${{ steps.secrets.outputs.HEX_API_KEY }}
+    steps:
+      - uses: 1password/load-secrets-action@v4
+        id: secrets
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          HEX_API_KEY: "${{ secrets.SECRETS_VAULT }}/HEX_API_KEY"
+
+  publish-docs:
+    needs: setup
+    strategy:
+      matrix:
+        package-name:
+          - one_piece_graceful_shutdown
+          - trogon_commanded
+          - trogon_error
+          - trogon_proto
+          - trogon_result
+          - trogon_typeprovider
+    uses: straw-hat-team/github-actions-workflows/.github/workflows/elixir-hex-publish-docs.yml@master
+    with:
+      package-name: ${{ matrix.package-name }}
+    secrets:
+      HEX_API_KEY: ${{ needs.setup.outputs.hex-api-key }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,18 @@
 name: hex-publish-docs
 
 on:
-  push:
-    branches:
-      - master
   workflow_dispatch:
+    inputs:
+      package-name:
+        description: Package to publish docs for
+        required: true
+        type: choice
+        options:
+          - trogon_commanded
+          - trogon_error
+          - trogon_proto
+          - trogon_result
+          - trogon_typeprovider
 
 jobs:
   publish-docs:
@@ -21,20 +29,4 @@ jobs:
       - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@master
         with:
           hex-api-key: ${{ env.HEX_API_KEY }}
-          package-name: trogon_commanded
-      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@master
-        with:
-          hex-api-key: ${{ env.HEX_API_KEY }}
-          package-name: trogon_error
-      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@master
-        with:
-          hex-api-key: ${{ env.HEX_API_KEY }}
-          package-name: trogon_proto
-      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@master
-        with:
-          hex-api-key: ${{ env.HEX_API_KEY }}
-          package-name: trogon_result
-      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@master
-        with:
-          hex-api-key: ${{ env.HEX_API_KEY }}
-          package-name: trogon_typeprovider
+          package-name: ${{ inputs.package-name }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,21 +7,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    outputs:
-      hex-api-key: ${{ steps.secrets.outputs.HEX_API_KEY }}
-    steps:
-      - uses: 1password/load-secrets-action@v4
-        id: secrets
-        with:
-          export-env: true
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          HEX_API_KEY: "${{ secrets.SECRETS_VAULT }}/HEX_API_KEY"
-
   publish-docs:
-    needs: setup
+    name: Publish Docs to Hex.pm
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         package-name:
@@ -31,8 +19,15 @@ jobs:
           - trogon_proto
           - trogon_result
           - trogon_typeprovider
-    uses: straw-hat-team/github-actions-workflows/.github/workflows/elixir-hex-publish-docs.yml@master
-    with:
-      package-name: ${{ matrix.package-name }}
-    secrets:
-      HEX_API_KEY: ${{ needs.setup.outputs.hex-api-key }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: 1password/load-secrets-action@v4
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          HEX_API_KEY: "${{ secrets.SECRETS_VAULT }}/HEX_API_KEY"
+      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@master
+        with:
+          hex-api-key: ${{ env.HEX_API_KEY }}
+          package-name: ${{ matrix.package-name }}


### PR DESCRIPTION
- Hex docs publishing was only possible as a side-effect of a full release; this adds an independent workflow so docs can be updated on every push to master without cutting a new package version