### PR TITLE
feat(trogon_proto): align env loaders with enum casting contract

### DIFF
--- a/apps/trogon_proto/lib/trogon/proto/env.ex
+++ b/apps/trogon_proto/lib/trogon/proto/env.ex
@@ -401,21 +401,16 @@ defmodule Trogon.Proto.Env do
   end
 
   defp parse_enum_value(value, enum_module) when is_binary(value) do
-    try do
-      enum_value =
-        value
-        |> enum_module.value()
-        |> enum_module.key()
-
-      if is_atom(enum_value) do
-        {:ok, enum_value}
-      else
-        {:error, invalid_enum_value_reason(value, enum_module)}
-      end
-    rescue
-      FunctionClauseError ->
-        {:error, invalid_enum_value_reason(value, enum_module)}
+    with {:ok, enum_tag} <- fetch_enum_tag(value, enum_module) do
+      {:ok, enum_module.key(enum_tag)}
     end
+  end
+
+  defp fetch_enum_tag(value, enum_module) do
+    {:ok, enum_module.value(value)}
+  rescue
+    FunctionClauseError ->
+      {:error, invalid_enum_value_reason(value, enum_module)}
   end
 
   defp invalid_enum_value_reason(value, enum_module) do

--- a/apps/trogon_proto/lib/trogon/proto/env.ex
+++ b/apps/trogon_proto/lib/trogon/proto/env.ex
@@ -52,6 +52,7 @@ defmodule Trogon.Proto.Env do
   - `float`, `double` - Parsed via `Float.parse/1` (accepts both "1.5" and "1")
   - `bool` - Case-insensitive, truthy values: `"true"`, `"1"`, `"yes"`, `"on"`;
     all other values are considered `false`
+  - `enum` - Exact enum name match (for example `"LOG_LEVEL_DEBUG"`)
   """
 
   alias TrogonProto.Env.V1Alpha1.FieldOptions
@@ -73,7 +74,7 @@ defmodule Trogon.Proto.Env do
           env_var_name: String.t(),
           visibility: non_neg_integer(),
           default_value: String.t() | nil,
-          field_type: atom(),
+          field_type: atom() | {:enum, module()},
           is_repeated: boolean(),
           split_delimiter: String.t(),
           trim: Trim.t() | nil
@@ -148,6 +149,13 @@ defmodule Trogon.Proto.Env do
   defp to_scalar(value, :double), do: parse_float(value)
   defp to_scalar(value, :bool), do: String.downcase(value) in ["true", "1", "yes", "on"]
 
+  defp to_scalar(value, {:enum, enum_module}) do
+    case parse_enum_value(value, enum_module) do
+      {:ok, enum_value} -> enum_value
+      {:error, reason} -> raise ArgumentError, reason
+    end
+  end
+
   defp parse_float(value) do
     case Float.parse(value) do
       {float, _} -> float
@@ -161,6 +169,13 @@ defmodule Trogon.Proto.Env do
   defp normalize_type(:TYPE_FLOAT), do: :float
   defp normalize_type(:TYPE_DOUBLE), do: :double
   defp normalize_type(:TYPE_BOOL), do: :bool
+  defp normalize_type(:string), do: :string
+  defp normalize_type(:int32), do: :int32
+  defp normalize_type(:int64), do: :int64
+  defp normalize_type(:float), do: :float
+  defp normalize_type(:double), do: :double
+  defp normalize_type(:bool), do: :bool
+  defp normalize_type({:enum, enum_module}) when is_atom(enum_module), do: {:enum, enum_module}
 
   @doc """
   Defines an environment variable loader struct from a protobuf message.
@@ -221,48 +236,50 @@ defmodule Trogon.Proto.Env do
   @spec extract_field_options(module()) :: map()
   defp extract_field_options(message_module) do
     desc = message_module.descriptor()
+    field_props = message_module.__message_props__().field_props
 
     desc.field
-    |> Enum.map(&extract_field_option/1)
+    |> Enum.map(&extract_field_option(&1, Map.fetch!(field_props, &1.number)))
     |> Enum.reject(&is_nil/1)
     |> Map.new()
   end
 
-  defp extract_field_option(field_desc) do
+  defp extract_field_option(field_desc, field_prop) do
     case get_field_extension(field_desc.options, @extension_tag) do
       nil -> nil
-      binary -> process_env_var_extension(field_desc, binary)
+      binary -> process_env_var_extension(field_desc, field_prop, binary)
     end
   end
 
-  defp process_env_var_extension(field_desc, binary) do
+  defp process_env_var_extension(field_desc, field_prop, binary) do
     %{env_var: env_var_option} = FieldOptions.decode(binary)
-    is_repeated = field_desc.label == :LABEL_REPEATED
+    is_repeated = field_prop.repeated?
+    field_type = field_prop.type
 
     cond do
       is_nil(env_var_option) ->
         warn_empty_env_var_extension(field_desc)
         nil
 
-      valid_env_field?(field_desc.type, is_repeated, env_var_option) ->
-        {String.to_atom(field_desc.name), build_field_config(field_desc, env_var_option, is_repeated)}
+      valid_env_field?(field_type, is_repeated, env_var_option) ->
+        {String.to_atom(field_desc.name), build_field_config(field_desc, field_type, env_var_option, is_repeated)}
 
       true ->
-        warn_unsupported_field(field_desc, is_repeated)
+        warn_unsupported_field(field_desc, field_type, is_repeated)
         nil
     end
   end
 
-  defp build_field_config(field_desc, env_var_option, is_repeated) do
+  defp build_field_config(field_desc, field_type, env_var_option, is_repeated) do
     default_value = env_var_option.default_value
 
-    validate_default_value!(field_desc.name, field_desc.type, default_value)
+    validate_default_value!(field_desc.name, field_type, default_value)
 
     %{
       env_var_name: field_name_to_env_var(field_desc.name),
       visibility: visibility_value(env_var_option.visibility),
       default_value: default_value,
-      field_type: field_desc.type,
+      field_type: field_type,
       is_repeated: is_repeated,
       split_delimiter: env_var_option.split_delimiter || "",
       trim: env_var_option.trim
@@ -288,6 +305,7 @@ defmodule Trogon.Proto.Env do
 
   defp validate_parseable(_value, :string), do: :ok
   defp validate_parseable(_value, :bool), do: :ok
+  defp validate_parseable(value, {:enum, enum_module}), do: validate_enum_value(value, enum_module)
 
   defp validate_parseable(value, type) when type in [:int32, :int64] do
     case Integer.parse(value) do
@@ -304,6 +322,13 @@ defmodule Trogon.Proto.Env do
     end
   end
 
+  defp validate_enum_value(value, enum_module) do
+    case parse_enum_value(value, enum_module) do
+      {:ok, _enum_value} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   defp warn_empty_env_var_extension(field_desc) do
     IO.warn(
       "Field #{field_desc.name} has env_var extension but env_var is empty; skipping.",
@@ -315,7 +340,7 @@ defmodule Trogon.Proto.Env do
   defp visibility_value(int) when is_integer(int), do: int
   defp visibility_value(nil), do: Visibility.value(:VISIBILITY_UNSPECIFIED)
 
-  defp warn_unsupported_field(field_desc, is_repeated) do
+  defp warn_unsupported_field(field_desc, field_type, is_repeated) do
     label_str =
       case field_desc.label do
         :LABEL_REPEATED -> "repeated "
@@ -324,8 +349,8 @@ defmodule Trogon.Proto.Env do
       end
 
     message =
-      "Field #{field_desc.name} has env_var extension but unsupported type #{label_str}#{inspect(field_desc.type)}. " <>
-        "Only scalar string, int32, int64, float, double, and bool fields are supported" <>
+      "Field #{field_desc.name} has env_var extension but unsupported type #{label_str}#{inspect(field_type)}. " <>
+        "Only scalar string, int32, int64, float, double, bool, and enum fields are supported" <>
         if is_repeated do
           " (repeated fields require split_delimiter)"
         else
@@ -340,20 +365,27 @@ defmodule Trogon.Proto.Env do
   end
 
   defp valid_env_field?(field_type, is_repeated, env_var_option) when not is_nil(env_var_option) do
-    scalar_supported = supported_scalar_type?(field_type)
+    scalar_supported = supported_env_type?(field_type)
     repeated_ok = not is_repeated || has_split_delimiter?(env_var_option)
     scalar_supported && repeated_ok
   end
 
   defp valid_env_field?(_, _, _), do: false
 
-  defp supported_scalar_type?(:TYPE_STRING), do: true
-  defp supported_scalar_type?(:TYPE_INT32), do: true
-  defp supported_scalar_type?(:TYPE_INT64), do: true
-  defp supported_scalar_type?(:TYPE_FLOAT), do: true
-  defp supported_scalar_type?(:TYPE_DOUBLE), do: true
-  defp supported_scalar_type?(:TYPE_BOOL), do: true
-  defp supported_scalar_type?(_), do: false
+  defp supported_env_type?(:TYPE_STRING), do: true
+  defp supported_env_type?(:TYPE_INT32), do: true
+  defp supported_env_type?(:TYPE_INT64), do: true
+  defp supported_env_type?(:TYPE_FLOAT), do: true
+  defp supported_env_type?(:TYPE_DOUBLE), do: true
+  defp supported_env_type?(:TYPE_BOOL), do: true
+  defp supported_env_type?(:string), do: true
+  defp supported_env_type?(:int32), do: true
+  defp supported_env_type?(:int64), do: true
+  defp supported_env_type?(:float), do: true
+  defp supported_env_type?(:double), do: true
+  defp supported_env_type?(:bool), do: true
+  defp supported_env_type?({:enum, enum_module}) when is_atom(enum_module), do: true
+  defp supported_env_type?(_), do: false
 
   defp get_field_extension(nil, _tag), do: nil
 
@@ -366,5 +398,32 @@ defmodule Trogon.Proto.Env do
 
   defp field_name_to_env_var(field_name) when is_binary(field_name) do
     String.upcase(field_name)
+  end
+
+  defp parse_enum_value(value, enum_module) when is_binary(value) do
+    case Map.fetch(enum_module.__reverse_mapping__(), value) do
+      {:ok, enum_value} ->
+        {:ok, enum_value}
+
+      :error ->
+        {:error, invalid_enum_value_reason(value, enum_module)}
+    end
+  end
+
+  defp invalid_enum_value_reason(value, enum_module) do
+    available =
+      enum_module
+      |> enum_names()
+      |> Enum.join(", ")
+
+    "not a valid enum name #{inspect(value)} for #{inspect(enum_module)}. Expected one of: #{available}"
+  end
+
+  defp enum_names(enum_module) do
+    enum_module
+    |> apply(:mapping, [])
+    |> Map.keys()
+    |> Enum.map(&Atom.to_string/1)
+    |> Enum.sort()
   end
 end

--- a/apps/trogon_proto/lib/trogon/proto/env.ex
+++ b/apps/trogon_proto/lib/trogon/proto/env.ex
@@ -401,11 +401,19 @@ defmodule Trogon.Proto.Env do
   end
 
   defp parse_enum_value(value, enum_module) when is_binary(value) do
-    case Map.fetch(enum_module.__reverse_mapping__(), value) do
-      {:ok, enum_value} ->
-        {:ok, enum_value}
+    try do
+      enum_value =
+        value
+        |> enum_module.value()
+        |> enum_module.key()
 
-      :error ->
+      if is_atom(enum_value) do
+        {:ok, enum_value}
+      else
+        {:error, invalid_enum_value_reason(value, enum_module)}
+      end
+    rescue
+      FunctionClauseError ->
         {:error, invalid_enum_value_reason(value, enum_module)}
     end
   end

--- a/apps/trogon_proto/test/proto/acme/test_enum.proto
+++ b/apps/trogon_proto/test/proto/acme/test_enum.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package acme.test.v1;
+
+import "trogon/env/v1alpha1/options.proto";
+
+enum LogLevel {
+  LOG_LEVEL_UNSPECIFIED = 0;
+  LOG_LEVEL_DEBUG = 1;
+  LOG_LEVEL_INFO = 2;
+  LOG_LEVEL_WARN = 3;
+  LOG_LEVEL_ERROR = 4;
+}
+
+message TestEnumConfig {
+  string database_url = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_SECRET
+  }];
+
+  LogLevel log_level = 2 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT,
+    default_value: "LOG_LEVEL_INFO"
+  }];
+
+  repeated LogLevel log_levels = 3 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT,
+    split_delimiter: ",",
+    trim: {unicode_whitespace: {}}
+  }];
+}

--- a/apps/trogon_proto/test/proto/acme/test_enum_invalid_default.proto
+++ b/apps/trogon_proto/test/proto/acme/test_enum_invalid_default.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package acme.test.v1;
+
+import "trogon/env/v1alpha1/options.proto";
+import "acme/test_enum.proto";
+
+message TestEnumInvalidDefault {
+  LogLevel log_level = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT,
+    default_value: "debug"
+  }];
+}

--- a/apps/trogon_proto/test/support/env/config_with_enum.ex
+++ b/apps/trogon_proto/test/support/env/config_with_enum.ex
@@ -1,0 +1,3 @@
+defmodule Trogon.Proto.TestSupport.ConfigWithEnum do
+  use Trogon.Proto.Env, message: Acme.Test.V1.TestEnumConfig
+end

--- a/apps/trogon_proto/test/support/proto/acme/test_enum.pb.ex
+++ b/apps/trogon_proto/test/support/proto/acme/test_enum.pb.ex
@@ -50,11 +50,11 @@ defmodule Acme.Test.V1.LogLevel do
     }
   end
 
-  field :LOG_LEVEL_UNSPECIFIED, 0
-  field :LOG_LEVEL_DEBUG, 1
-  field :LOG_LEVEL_INFO, 2
-  field :LOG_LEVEL_WARN, 3
-  field :LOG_LEVEL_ERROR, 4
+  field(:LOG_LEVEL_UNSPECIFIED, 0)
+  field(:LOG_LEVEL_DEBUG, 1)
+  field(:LOG_LEVEL_INFO, 2)
+  field(:LOG_LEVEL_WARN, 3)
+  field(:LOG_LEVEL_ERROR, 4)
 end
 
 defmodule Acme.Test.V1.TestEnumConfig do
@@ -126,8 +126,7 @@ defmodule Acme.Test.V1.TestEnumConfig do
             uninterpreted_option: [],
             __pb_extensions__: %{},
             __unknown_fields__: [
-              {870_003, 2,
-               <<10, 18, 8, 1, 18, 14, 76, 79, 71, 95, 76, 69, 86, 69, 76, 95, 73, 78, 70, 79>>}
+              {870_003, 2, <<10, 18, 8, 1, 18, 14, 76, 79, 71, 95, 76, 69, 86, 69, 76, 95, 73, 78, 70, 79>>}
             ]
           },
           oneof_index: nil,
@@ -179,18 +178,20 @@ defmodule Acme.Test.V1.TestEnumConfig do
     }
   end
 
-  field :database_url, 1, type: :string, json_name: "databaseUrl", deprecated: false
+  field(:database_url, 1, type: :string, json_name: "databaseUrl", deprecated: false)
 
-  field :log_level, 2,
+  field(:log_level, 2,
     type: Acme.Test.V1.LogLevel,
     json_name: "logLevel",
     enum: true,
     deprecated: false
+  )
 
-  field :log_levels, 3,
+  field(:log_levels, 3,
     repeated: true,
     type: Acme.Test.V1.LogLevel,
     json_name: "logLevels",
     enum: true,
     deprecated: false
+  )
 end

--- a/apps/trogon_proto/test/support/proto/acme/test_enum.pb.ex
+++ b/apps/trogon_proto/test/support/proto/acme/test_enum.pb.ex
@@ -1,0 +1,196 @@
+defmodule Acme.Test.V1.LogLevel do
+  @moduledoc false
+
+  use Protobuf,
+    enum: true,
+    full_name: "acme.test.v1.LogLevel",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.EnumDescriptorProto{
+      name: "LogLevel",
+      value: [
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "LOG_LEVEL_UNSPECIFIED",
+          number: 0,
+          options: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "LOG_LEVEL_DEBUG",
+          number: 1,
+          options: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "LOG_LEVEL_INFO",
+          number: 2,
+          options: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "LOG_LEVEL_WARN",
+          number: 3,
+          options: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "LOG_LEVEL_ERROR",
+          number: 4,
+          options: nil,
+          __unknown_fields__: []
+        }
+      ],
+      options: nil,
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field :LOG_LEVEL_UNSPECIFIED, 0
+  field :LOG_LEVEL_DEBUG, 1
+  field :LOG_LEVEL_INFO, 2
+  field :LOG_LEVEL_WARN, 3
+  field :LOG_LEVEL_ERROR, 4
+end
+
+defmodule Acme.Test.V1.TestEnumConfig do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestEnumConfig",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestEnumConfig",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "database_url",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [{870_003, 2, <<10, 2, 8, 2>>}]
+          },
+          oneof_index: nil,
+          json_name: "databaseUrl",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "log_level",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_ENUM,
+          type_name: ".acme.test.v1.LogLevel",
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [
+              {870_003, 2,
+               <<10, 18, 8, 1, 18, 14, 76, 79, 71, 95, 76, 69, 86, 69, 76, 95, 73, 78, 70, 79>>}
+            ]
+          },
+          oneof_index: nil,
+          json_name: "logLevel",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "log_levels",
+          extendee: nil,
+          number: 3,
+          label: :LABEL_REPEATED,
+          type: :TYPE_ENUM,
+          type_name: ".acme.test.v1.LogLevel",
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [{870_003, 2, <<10, 9, 8, 1, 34, 1, 44, 42, 2, 10, 0>>}]
+          },
+          oneof_index: nil,
+          json_name: "logLevels",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field :database_url, 1, type: :string, json_name: "databaseUrl", deprecated: false
+
+  field :log_level, 2,
+    type: Acme.Test.V1.LogLevel,
+    json_name: "logLevel",
+    enum: true,
+    deprecated: false
+
+  field :log_levels, 3,
+    repeated: true,
+    type: Acme.Test.V1.LogLevel,
+    json_name: "logLevels",
+    enum: true,
+    deprecated: false
+end

--- a/apps/trogon_proto/test/support/proto/acme/test_enum_invalid_default.pb.ex
+++ b/apps/trogon_proto/test/support/proto/acme/test_enum_invalid_default.pb.ex
@@ -55,9 +55,10 @@ defmodule Acme.Test.V1.TestEnumInvalidDefault do
     }
   end
 
-  field :log_level, 1,
+  field(:log_level, 1,
     type: Acme.Test.V1.LogLevel,
     json_name: "logLevel",
     enum: true,
     deprecated: false
+  )
 end

--- a/apps/trogon_proto/test/support/proto/acme/test_enum_invalid_default.pb.ex
+++ b/apps/trogon_proto/test/support/proto/acme/test_enum_invalid_default.pb.ex
@@ -1,0 +1,63 @@
+defmodule Acme.Test.V1.TestEnumInvalidDefault do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestEnumInvalidDefault",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestEnumInvalidDefault",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "log_level",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_ENUM,
+          type_name: ".acme.test.v1.LogLevel",
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [{870_003, 2, <<10, 9, 8, 1, 18, 5, 100, 101, 98, 117, 103>>}]
+          },
+          oneof_index: nil,
+          json_name: "logLevel",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field :log_level, 1,
+    type: Acme.Test.V1.LogLevel,
+    json_name: "logLevel",
+    enum: true,
+    deprecated: false
+end

--- a/apps/trogon_proto/test/trogon/proto/env_test.exs
+++ b/apps/trogon_proto/test/trogon/proto/env_test.exs
@@ -4,6 +4,7 @@ defmodule Trogon.Proto.EnvTest do
   alias Trogon.Proto.Env
   alias Trogon.Proto.TestSupport
   alias Trogon.Proto.TestSupport.AllTypesConfig
+  alias Trogon.Proto.TestSupport.ConfigWithEnum
   alias Trogon.Proto.TestSupport.ConfigWithRepeated
   alias Trogon.Proto.TestSupport.ConfigWithTrimCustom
   alias Trogon.Proto.TestSupport.ConfigWithTrimUnicode
@@ -113,6 +114,28 @@ defmodule Trogon.Proto.EnvTest do
 
       assert_raise ArgumentError, ~r/not a valid float/, fn ->
         Env.convert_field("not_a_number", config)
+      end
+    end
+
+    test "converts enum names to protobuf enum atoms" do
+      config = %{field_type: {:enum, Acme.Test.V1.LogLevel}, is_repeated: false, split_delimiter: "", trim: nil}
+
+      assert Env.convert_field("LOG_LEVEL_DEBUG", config) == :LOG_LEVEL_DEBUG
+    end
+
+    test "raises ArgumentError for invalid enum names" do
+      config = %{field_type: {:enum, Acme.Test.V1.LogLevel}, is_repeated: false, split_delimiter: "", trim: nil}
+
+      assert_raise ArgumentError, ~r/not a valid enum name "debug"/, fn ->
+        Env.convert_field("debug", config)
+      end
+    end
+
+    test "does not treat numeric strings as enum values" do
+      config = %{field_type: {:enum, Acme.Test.V1.LogLevel}, is_repeated: false, split_delimiter: "", trim: nil}
+
+      assert_raise ArgumentError, ~r/not a valid enum name "1"/, fn ->
+        Env.convert_field("1", config)
       end
     end
   end
@@ -532,6 +555,82 @@ defmodule Trogon.Proto.EnvTest do
 
       assert config.env.tags == ["foo", "bar"]
       assert config.env.port_list == [8080, 9000]
+    end
+  end
+
+  describe "enum fields" do
+    test "applies enum defaults when the scalar enum env var is absent" do
+      TestSupport.stub_system_env(%{
+        "DATABASE_URL" => "postgres://localhost",
+        "LOG_LEVELS" => ""
+      })
+
+      config = ConfigWithEnum.from_env!()
+
+      assert config.env.database_url == "postgres://localhost"
+      assert config.env.log_level == :LOG_LEVEL_INFO
+      assert config.env.log_levels == []
+    end
+
+    test "converts enum env var values by exact name" do
+      TestSupport.stub_system_env(%{
+        "DATABASE_URL" => "postgres://localhost",
+        "LOG_LEVEL" => "LOG_LEVEL_DEBUG",
+        "LOG_LEVELS" => "LOG_LEVEL_WARN, LOG_LEVEL_ERROR"
+      })
+
+      config = ConfigWithEnum.from_env!()
+
+      assert config.env.log_level == :LOG_LEVEL_DEBUG
+      assert config.env.log_levels == [:LOG_LEVEL_WARN, :LOG_LEVEL_ERROR]
+    end
+
+    test "trims repeated enum values before exact-name lookup" do
+      TestSupport.stub_system_env(%{
+        "DATABASE_URL" => "postgres://localhost",
+        "LOG_LEVELS" => "  LOG_LEVEL_WARN  ,  LOG_LEVEL_ERROR  "
+      })
+
+      config = ConfigWithEnum.from_env!()
+
+      assert config.env.log_levels == [:LOG_LEVEL_WARN, :LOG_LEVEL_ERROR]
+    end
+
+    test "raises ArgumentError for enum env vars that do not match a value name exactly" do
+      TestSupport.stub_system_env(%{
+        "DATABASE_URL" => "postgres://localhost",
+        "LOG_LEVEL" => "debug"
+      })
+
+      assert_raise ArgumentError, ~r/not a valid enum name "debug"/, fn ->
+        ConfigWithEnum.from_env!()
+      end
+    end
+
+    test "does not cast numeric enum env vars by tag" do
+      TestSupport.stub_system_env(%{
+        "DATABASE_URL" => "postgres://localhost",
+        "LOG_LEVEL" => "1"
+      })
+
+      assert_raise ArgumentError, ~r/not a valid enum name "1"/, fn ->
+        ConfigWithEnum.from_env!()
+      end
+    end
+
+    test "raises CompileError for invalid enum defaults" do
+      module = Module.concat(__MODULE__, :"InvalidEnumConfig#{System.unique_integer([:positive])}")
+
+      quoted =
+        quote do
+          defmodule unquote(module) do
+            use Trogon.Proto.Env, message: Acme.Test.V1.TestEnumInvalidDefault
+          end
+        end
+
+      assert_raise CompileError, ~r/Field log_level has invalid default_value "debug"/, fn ->
+        Code.compile_quoted(quoted)
+      end
     end
   end
 end


### PR DESCRIPTION
- Env-backed protobuf configs could not express enum fields, which left `Trogon.Proto.Env` behind the enum casting contract documented in TrogonStack/trogon-proto#36.
- Defines exact-name enum resolution so env loading stays deterministic and avoids ambiguous numeric or case-variant inputs.
- Keeps invalid enum defaults and invalid runtime values from slipping through unnoticed.