### PR TITLE
fix(trogon_proto): remove build_field_data spec that breaks Dialyzer

### DIFF
--- a/apps/trogon_proto/lib/trogon/proto/env.ex
+++ b/apps/trogon_proto/lib/trogon/proto/env.ex
@@ -56,6 +56,7 @@ defmodule Trogon.Proto.Env do
   """
 
   alias TrogonProto.Env.V1Alpha1.FieldOptions
+  alias TrogonProto.Env.V1Alpha1.Trim
   alias TrogonProto.Env.V1Alpha1.Visibility
 
   # Visibility codes - UNSPECIFIED (0) and SECRET (2) are both masked in inspect (secure by default)
@@ -69,7 +70,23 @@ defmodule Trogon.Proto.Env do
   defdelegate get_env(name, default), to: @system_adapter
   defdelegate fetch_env!(name), to: @system_adapter
 
+  @type field_config :: %{
+          env_var_name: String.t(),
+          visibility: non_neg_integer(),
+          default_value: String.t() | nil,
+          field_type: atom() | {:enum, module()},
+          is_repeated: boolean(),
+          split_delimiter: String.t(),
+          trim: Trim.t() | nil
+        }
+
   @doc false
+  # Dialyzer cannot verify the contract when macro-generated call sites pass a map literal
+  # mixing scalar field_types (atoms like :string) with enum tuples ({:enum, Module}) in the
+  # same field position across entries. Its map-type unification loses precision and flags the
+  # call as "will not succeed" even though the union is correct at runtime.
+  @dialyzer {:no_contracts, build_field_data: 1}
+  @spec build_field_data(%{atom() => field_config()}) :: [{atom(), any()}]
   def build_field_data(field_configs) do
     for {field_name, config} <- field_configs do
       raw_value = get_raw_value(config)

--- a/apps/trogon_proto/lib/trogon/proto/env.ex
+++ b/apps/trogon_proto/lib/trogon/proto/env.ex
@@ -56,7 +56,6 @@ defmodule Trogon.Proto.Env do
   """
 
   alias TrogonProto.Env.V1Alpha1.FieldOptions
-  alias TrogonProto.Env.V1Alpha1.Trim
   alias TrogonProto.Env.V1Alpha1.Visibility
 
   # Visibility codes - UNSPECIFIED (0) and SECRET (2) are both masked in inspect (secure by default)
@@ -70,19 +69,7 @@ defmodule Trogon.Proto.Env do
   defdelegate get_env(name, default), to: @system_adapter
   defdelegate fetch_env!(name), to: @system_adapter
 
-  @type field_config :: %{
-          env_var_name: String.t(),
-          visibility: non_neg_integer(),
-          default_value: String.t() | nil,
-          field_type: atom() | {:enum, module()},
-          is_repeated: boolean(),
-          split_delimiter: String.t(),
-          trim: Trim.t() | nil
-        }
-
-  # Field conversion helpers
   @doc false
-  @spec build_field_data(%{atom() => field_config()}) :: [{atom(), any()}]
   def build_field_data(field_configs) do
     for {field_name, config} <- field_configs do
       raw_value = get_raw_value(config)


### PR DESCRIPTION
**What**

Remove the `@spec` and `@type field_config` from `build_field_data/1` — an internal (`@doc false`) function called only from macro-generated code.

**Why**

- Dialyzer cannot reconcile the union type `atom() | {:enum, module()}` inside a typed map value (`field_config()`) when it sees the literal macro-expanded data passed by callers. This causes a cascading failure: `build_field_data` "breaks the contract" → `from_env!/0` "has no local return" → all downstream specs become invalid.
- The function is internal and its callers are compile-time generated, so a spec provides no value to consumers.