### PR TITLE
feat(trogon_error): let apps tailor help links

### DIFF
--- a/apps/trogon_error/lib/trogon/error.ex
+++ b/apps/trogon_error/lib/trogon/error.ex
@@ -592,6 +592,39 @@ defmodule Trogon.Error do
   def to_http_status_code(:DATA_LOSS), do: 500
   def to_http_status_code(:UNAUTHENTICATED), do: 401
 
+  @doc ~S"""
+  Updates the help links for a Trogon error.
+
+  The updater receives the error and the current links list, normalized from `nil`
+  to `[]`, and must return the replacement links list.
+
+  ## Examples
+
+      iex> defmodule MyApp.Error.InsufficientInventoryError do
+      ...>   use Trogon.Error,
+      ...>     domain: "com.myapp.inventory",
+      ...>     reason: "INSUFFICIENT_INVENTORY"
+      ...> end
+      iex> updater_links = fn err, links, principal_role ->
+      ...>   path = "/runbooks/" <> err.domain <> "/" <> err.reason <> "?role=#{principal_role}"
+      ...>   url = "https://docs.example.com" <> path
+      ...>   links ++ [%{description: "Runbook", url: url}]
+      ...> end
+      iex> err = MyApp.Error.InsufficientInventoryError.new!()
+      iex> err = Trogon.Error.update_help_links(err, &updater_links.(&1, &2, :ai_agent))
+      iex> err.help
+      %{links: [
+        %{description: "Runbook", url: "https://docs.example.com/runbooks/com.myapp.inventory/INSUFFICIENT_INVENTORY?role=ai_agent"}
+      ]}
+  """
+  @spec update_help_links(t(module()), (t(module()), list(help_link()) -> list(help_link()))) ::
+          t(module())
+  def update_help_links(error, updater) when is_function(updater, 2) do
+    links = updater.(error, current_help_links(error))
+
+    %{error | help: Map.put(error.help || %{}, :links, links)}
+  end
+
   @spec to_msg(atom() | String.t()) :: String.t()
   def to_msg(msg) when is_binary(msg), do: msg
   def to_msg(:CANCELLED), do: "the operation was cancelled"
@@ -636,6 +669,9 @@ defmodule Trogon.Error do
     |> Metadata.new()
     |> Macro.escape()
   end
+
+  defp current_help_links(%{help: %{links: links}}) when is_list(links), do: links
+  defp current_help_links(_error), do: []
 
   @doc "See `t:template_opt/0` for available options."
   @spec __using__([template_opt()]) :: Macro.t()

--- a/apps/trogon_error/test/trogon/error_test.exs
+++ b/apps/trogon_error/test/trogon/error_test.exs
@@ -542,6 +542,59 @@ defmodule Trogon.ErrorTest do
     end
   end
 
+  describe "update_help_links/2" do
+    test "passes the error and appends links using the caller-provided order" do
+      error = TestSupport.HelpfulError.new!()
+
+      error = Trogon.Error.update_help_links(error, &update_help_links(&1, &2, :ai_agent))
+
+      assert error.help == %{
+               links: [
+                 %{description: "API Docs", url: "https://example.com/docs"},
+                 %{
+                   description: "HELPFUL_ERROR",
+                   url: "https://docs.example.com/errors/com.test.help/HELPFUL_ERROR/ai_agent"
+                 }
+               ]
+             }
+    end
+
+    test "normalizes missing help links to an empty list" do
+      error = TestSupport.TestError.new!()
+      error = Trogon.Error.update_help_links(error, &prepend_priority_help_links/2)
+
+      assert error.help == %{
+               links: [
+                 %{description: "Priority Docs", url: "https://example.com/priority"}
+               ]
+             }
+    end
+
+    test "replaces the links with the updater result" do
+      error = TestSupport.HelpfulError.new!()
+      error = Trogon.Error.update_help_links(error, &replace_help_links/2)
+
+      assert error.help == %{
+               links: [
+                 %{description: "Replacement Docs", url: "https://example.com/replacement"}
+               ]
+             }
+    end
+  end
+
+  defp update_help_links(err, links, principal_type) do
+    url = "https://docs.example.com/errors/#{err.domain}/#{err.reason}/#{principal_type}"
+    links ++ [%{description: err.reason, url: url}]
+  end
+
+  defp prepend_priority_help_links(_err, links) do
+    [%{description: "Priority Docs", url: "https://example.com/priority"} | links]
+  end
+
+  defp replace_help_links(_err, _links) do
+    [%{description: "Replacement Docs", url: "https://example.com/replacement"}]
+  end
+
   describe "is_trogon_error?/1" do
     test "returns true for Trogon errors" do
       error = TestSupport.TestError.new!()


### PR DESCRIPTION
- let callers enrich help links without rebuilding or wrapping an error when app-level context only affects documentation guidance
- keep help-link ordering and merge policy at the boundary where principal-aware decisions already exist