### PR TITLE
fix(ci): pin release-please-action to commit SHA

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Release please
         id: release
-        uses: googleapis/release-please-action@v5
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json


### PR DESCRIPTION
- dependabot bump from v4 to v5 used a tag reference, which violates the repo's `sha_pinning_required` policy causing `startup_failure` on every workflow run since April 22