### PR TITLE
feat(trogon_commanded): support proto-driven enums

### DIFF
--- a/apps/trogon_commanded/lib/trogon/commanded/enum.ex
+++ b/apps/trogon_commanded/lib/trogon/commanded/enum.ex
@@ -32,8 +32,21 @@ defmodule Trogon.Commanded.Enum do
           field :type, BankAccountType
         end
       end
+
+  ## Proto-driven Enum
+
+  You can derive values from a protobuf enum module instead of a hardcoded list:
+
+      defmodule ObjectTypeEnum do
+        use Trogon.Commanded.Enum,
+          proto: Acme.Type.V1.ObjectType
+      end
+
+  This reads the enum values from the proto module's `mapping/0` at compile time,
+  sorted by their proto field number.
   """
   defmacro __using__(opts) do
+    opts = resolve_proto_options(opts, __CALLER__)
     values = Keyword.fetch!(opts, :values)
     type_ast = Enum.reduce(values, &{:|, [], [&1, &2]})
 
@@ -179,6 +192,20 @@ defmodule Trogon.Commanded.Enum do
           Jason.Encode.value(v.value, opts)
         end
       end
+    end
+  end
+
+  defp resolve_proto_options(opts, caller) do
+    case Keyword.pop(opts, :proto) do
+      {nil, opts} ->
+        opts
+
+      {proto_module, opts} ->
+        mod = Macro.expand(proto_module, caller)
+
+        Code.ensure_compiled!(mod)
+        values = mod.mapping() |> Map.keys() |> Enum.sort_by(&mod.value/1)
+        Keyword.put_new(opts, :values, values)
     end
   end
 end

--- a/apps/trogon_commanded/lib/trogon/commanded/enum.ex
+++ b/apps/trogon_commanded/lib/trogon/commanded/enum.ex
@@ -45,8 +45,10 @@ defmodule Trogon.Commanded.Enum do
   The enum values are derived at compile time, sorted by their proto field number.
   """
   defmacro __using__(opts) do
-    opts = resolve_proto_options(opts, __CALLER__)
-    values = Keyword.fetch!(opts, :values)
+    values =
+      opts
+      |> resolve_proto_options(__CALLER__)
+      |> Keyword.fetch!(:values)
     type_ast = Enum.reduce(values, &{:|, [], [&1, &2]})
 
     value_functions_ast =

--- a/apps/trogon_commanded/lib/trogon/commanded/enum.ex
+++ b/apps/trogon_commanded/lib/trogon/commanded/enum.ex
@@ -42,8 +42,7 @@ defmodule Trogon.Commanded.Enum do
           proto: Acme.Type.V1.ObjectType
       end
 
-  This reads the enum values from the proto module's `mapping/0` at compile time,
-  sorted by their proto field number.
+  The enum values are derived at compile time, sorted by their proto field number.
   """
   defmacro __using__(opts) do
     opts = resolve_proto_options(opts, __CALLER__)

--- a/apps/trogon_commanded/test/support/command_router_example/object_type_enum.ex
+++ b/apps/trogon_commanded/test/support/command_router_example/object_type_enum.ex
@@ -1,0 +1,6 @@
+defmodule TestSupport.CommandRouterExample.ObjectTypeEnum do
+  @moduledoc false
+
+  use Trogon.Commanded.Enum,
+    proto: Acme.Type.V1.ObjectType
+end

--- a/apps/trogon_commanded/test/trogon/commanded/enum_test.exs
+++ b/apps/trogon_commanded/test/trogon/commanded/enum_test.exs
@@ -2,6 +2,7 @@ defmodule Trogon.Commanded.EnumTest do
   use ExUnit.Case, async: true
 
   alias TestSupport.CommandRouterExample.BankAccountType
+  alias TestSupport.CommandRouterExample.ObjectTypeEnum
 
   describe "new/1" do
     test "returns a value object" do
@@ -149,5 +150,50 @@ defmodule Trogon.Commanded.EnumTest do
       })
 
     assert expected_value == given_value
+  end
+
+  describe "proto-driven enum" do
+    test "values/0 returns proto enum values sorted by number" do
+      assert ObjectTypeEnum.values() == [
+               :OBJECT_TYPE_UNSPECIFIED,
+               :OBJECT_TYPE_TICKET,
+               :OBJECT_TYPE_WORKSPACE
+             ]
+    end
+
+    test "new/1 with a valid proto enum value" do
+      assert {:ok, %ObjectTypeEnum{value: :OBJECT_TYPE_TICKET}} =
+               ObjectTypeEnum.new(:OBJECT_TYPE_TICKET)
+    end
+
+    test "new/1 with an invalid value" do
+      assert {:error, changeset} = ObjectTypeEnum.new(:INVALID)
+      assert %{value: ["is invalid"]} = TestSupport.errors_on(changeset)
+    end
+
+    test "cast/1 with atom" do
+      assert ObjectTypeEnum.cast(:OBJECT_TYPE_TICKET) ==
+               {:ok, %ObjectTypeEnum{value: :OBJECT_TYPE_TICKET}}
+    end
+
+    test "cast/1 with string" do
+      assert ObjectTypeEnum.cast("OBJECT_TYPE_TICKET") ==
+               {:ok, %ObjectTypeEnum{value: :OBJECT_TYPE_TICKET}}
+    end
+
+    test "load/1 with string" do
+      assert ObjectTypeEnum.load("OBJECT_TYPE_TICKET") ==
+               {:ok, %ObjectTypeEnum{value: :OBJECT_TYPE_TICKET}}
+    end
+
+    test "dump/1" do
+      assert ObjectTypeEnum.dump(%ObjectTypeEnum{value: :OBJECT_TYPE_TICKET}) ==
+               {:ok, "OBJECT_TYPE_TICKET"}
+    end
+
+    test "Jason.Encoder" do
+      assert Jason.encode!(%ObjectTypeEnum{value: :OBJECT_TYPE_TICKET}) ==
+               ~s("OBJECT_TYPE_TICKET")
+    end
   end
 end


### PR DESCRIPTION
- allow deriving `Trogon.Commanded.Enum` values from a protobuf enum module at compile time, same pattern used by `ObjectId` and `Trogon.Proto.Env`
- avoid duplicating enum value lists between proto definitions and commanded enum modules