### PR TITLE
feat(trogon_object_id): extract ObjectId into its own package

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -27,6 +27,9 @@
     },
     "apps/trogon_proto": {
       "component": "trogon_proto"
+    },
+    "apps/trogon_object_id": {
+      "component": "trogon_object_id"
     }
   },
   "plugins": [

--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -3,5 +3,6 @@
   "apps/trogon_result": "1.0.1",
   "apps/trogon_error": "0.6.0",
   "apps/trogon_typeprovider": "0.3.0",
-  "apps/trogon_proto": "0.8.0"
+  "apps/trogon_proto": "0.8.0",
+  "apps/trogon_object_id": "0.0.1"
 }

--- a/apps/trogon_object_id/.formatter.exs
+++ b/apps/trogon_object_id/.formatter.exs
@@ -1,0 +1,5 @@
+[
+  line_length: 120,
+  import_deps: [:ecto],
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/apps/trogon_object_id/LICENSE
+++ b/apps/trogon_object_id/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026-Present Straw Hat, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/trogon_object_id/README.md
+++ b/apps/trogon_object_id/README.md
@@ -1,0 +1,36 @@
+# Trogon.ObjectId
+
+**Type-safe, prefixed object IDs for Elixir applications.** Each ID type is its own struct, so `UserId` and `OrderId` can never be confused at compile time or runtime.
+
+**Define an ID with `use Trogon.ObjectId`, and you get creation, parsing, string conversion, JSON encoding, and Ecto type callbacks out of the box.** IDs are stored as `{prefix}{separator}{value}` strings (e.g., `"user_abc-123"`), with configurable storage and JSON formats. Union types (`Trogon.UnionObjectId`) let a single field accept any of several ID types, discriminated by prefix. Proto-driven definitions derive prefixes and separators from protobuf enum annotations.
+
+**Raw string IDs lose their meaning the moment they leave the function that created them — a user ID passed where an order ID was expected is a silent, runtime bug.** Trogon.ObjectId eliminates that class of error by making every ID a distinct struct that pattern-matches and type-specs enforce automatically.
+
+**Built for teams writing domain-driven Elixir services that use Ecto for persistence and need human-readable, type-safe identifiers across commands, events, and read models.**
+
+## How-to
+
+### Define an ObjectId
+
+```elixir
+defmodule MyApp.UserId do
+  use Trogon.ObjectId, object_type: "user"
+end
+
+{:ok, id} = MyApp.UserId.new("abc-123")
+"user_abc-123" = to_string(id)
+{:ok, ^id} = MyApp.UserId.parse("user_abc-123")
+```
+
+See `Trogon.ObjectId` module docs for all options (`separator`, `storage_format`, `json_format`, `validate`, `proto`).
+
+### Define a union of ObjectId types
+
+```elixir
+defmodule MyApp.PrincipalId do
+  use Trogon.UnionObjectId, types: [MyApp.TenantId, MyApp.SystemId]
+end
+
+{:ok, principal} = MyApp.PrincipalId.parse("tenant_abc-123")
+#=> {:ok, %MyApp.PrincipalId{id: %MyApp.TenantId{id: "abc-123"}}}
+```

--- a/apps/trogon_object_id/lib/trogon/object_id.ex
+++ b/apps/trogon_object_id/lib/trogon/object_id.ex
@@ -1,0 +1,589 @@
+defmodule Trogon.ObjectId do
+  @moduledoc """
+  Macro for defining type-safe, domain-specific object IDs.
+
+  ObjectIds are type-safe identifiers that combine a human-readable prefix with a value,
+  stored as `{prefix}{separator}{id}` (e.g., `"user_abc-123"`).
+
+  ## Usage
+
+      defmodule MyApp.UserId do
+        use Trogon.ObjectId,
+          object_type: "user"
+      end
+
+      # Create
+      user_id = MyApp.UserId.new("abc-123")
+      #=> %MyApp.UserId{id: "abc-123"}
+
+      # Convert to string
+      to_string(user_id)
+      #=> "user_abc-123"
+
+      # Parse
+      MyApp.UserId.parse("user_abc-123")
+      #=> {:ok, %MyApp.UserId{id: "abc-123"}}
+
+  ## Type Safety
+
+  Each ObjectId type is a separate struct, providing compile-time and runtime type safety:
+
+      def process_user(%MyApp.UserId{} = id), do: ...
+      def process_order(%MyApp.OrderId{} = id), do: ...
+
+      process_user(MyApp.OrderId.new("123"))  #=> FunctionClauseError!
+
+  ## Proto-driven ObjectId
+
+  When using `trogon_proto` with `trogon/object_id/v1alpha1/options.proto`, you can
+  derive `object_type` and `separator` from proto enum value extensions:
+
+      defmodule MyApp.TicketId do
+        use Trogon.ObjectId,
+          proto: {Acme.Type.V1.ObjectType, :OBJECT_TYPE_TICKET},
+          storage_format: :drop_prefix,
+          validate: :uuid
+      end
+
+  This reads `object_type` and `separator` from the proto annotation and forwards
+  them along with any additional options you provide.
+
+  ## Ecto Integration
+
+  ObjectIds implement `Ecto.Type`, so you can use them directly in schemas:
+
+      schema "users" do
+        field :id, MyApp.UserId
+      end
+  """
+
+  alias Trogon.ObjectId.ProtoExtension
+  alias TrogonProto.ObjectId.V1Alpha1.EnumValueOptions, as: ObjectIdEnumValueOptions
+
+  @doc """
+  Returns true if `term` is an ObjectId struct; otherwise returns false.
+
+  Allowed in guard tests.
+
+  ## Examples
+
+      iex> is_object_id(%MyApp.UserId{id: "abc-123"})
+      true
+
+      iex> is_object_id(%{id: "abc-123"})
+      false
+  """
+  defguard is_object_id(term)
+           when is_map(term) and :erlang.is_map_key(:__object_id__, term) and
+                  :erlang.map_get(:__object_id__, term) == true
+
+  @proto_extension_tag 870_010
+  @proto_extension_name "trogon.object_id.v1alpha1.enum_value"
+  @default_separator "_"
+
+  @using_opts_schema NimbleOptions.new!(
+                       object_type: [
+                         type: :string,
+                         required: true,
+                         doc: "The object type (e.g., `\"user\"`, `\"order\"`)."
+                       ],
+                       separator: [
+                         type: :string,
+                         default: "_",
+                         doc: "Separator between prefix and id."
+                       ],
+                       storage_format: [
+                         type: {:in, [:full, :drop_prefix]},
+                         default: :full,
+                         doc: """
+                         Database storage format.
+                         - `:full` - Store complete string (e.g., `"user_abc-123"`)
+                         - `:drop_prefix` - Store only the id (e.g., `"abc-123"`)
+                         """
+                       ],
+                       json_format: [
+                         type: {:in, [:full, :drop_prefix]},
+                         default: :full,
+                         doc: """
+                         JSON encoding format.
+                         - `:full` - Encode complete string (e.g., `"user_abc-123"`)
+                         - `:drop_prefix` - Encode only the id (e.g., `"abc-123"`)
+                         """
+                       ],
+                       validate: [
+                         type: {:or, [{:in, [nil, :uuid, :integer]}, {:tuple, [:atom, :atom]}]},
+                         default: nil,
+                         doc: """
+                         Validation for the raw id value (without prefix).
+                         - `nil` - No validation (default)
+                         - `:uuid` - Validates that the id is a valid UUID
+                         - `:integer` - Validates that the id is a valid integer string
+                         - `{Module, :function}` - Custom validator (compile-time optimized direct call).
+                           The function receives the raw id value and returns `:ok` or `{:error, reason}`.
+                         """
+                       ]
+                     )
+
+  defp expand_validate({module, function}, caller), do: {Macro.expand(module, caller), function}
+  defp expand_validate(other, _caller), do: other
+
+  defp validate_mf!({module, function}) do
+    cond do
+      not Code.ensure_loaded?(module) ->
+        :ok
+
+      not function_exported?(module, function, 1) ->
+        raise ArgumentError, "#{inspect(module)}.#{function}/1 is not defined"
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_mf!(_), do: :ok
+
+  @doc """
+  Defines a type-safe ObjectId module.
+
+  ## Options
+
+  #{NimbleOptions.docs(@using_opts_schema)}
+
+  ## Examples
+
+      defmodule MyApp.UserId do
+        use Trogon.ObjectId, object_type: "user"
+      end
+
+      defmodule MyApp.OrderId do
+        use Trogon.ObjectId, object_type: "order", separator: "#"
+      end
+
+      defmodule MyApp.AccountId do
+        use Trogon.ObjectId, object_type: "acct", storage_format: :drop_prefix
+      end
+
+      # With UUID validation
+      defmodule MyApp.ProductId do
+        use Trogon.ObjectId, object_type: "product", validate: :uuid
+      end
+
+      # With integer validation
+      defmodule MyApp.SequenceId do
+        use Trogon.ObjectId, object_type: "seq", validate: :integer
+      end
+
+      # With custom validator (compile-time optimized)
+      defmodule MyApp.CustomId do
+        use Trogon.ObjectId,
+          object_type: "custom",
+          validate: {MyValidator, :check}
+      end
+  """
+  defmacro __using__(opts) do
+    opts =
+      opts
+      |> resolve_proto_options(__CALLER__)
+      |> Keyword.update(:validate, nil, &expand_validate(&1, __CALLER__))
+      |> NimbleOptions.validate!(@using_opts_schema)
+
+    object_type = Keyword.fetch!(opts, :object_type)
+    separator = Keyword.fetch!(opts, :separator)
+    storage_format = Keyword.fetch!(opts, :storage_format)
+    json_format = Keyword.fetch!(opts, :json_format)
+    validate = Keyword.get(opts, :validate)
+
+    :ok = validate_mf!(validate)
+
+    # Precompute at compile time
+    prefix = object_type <> separator
+    prefix_len = byte_size(prefix)
+
+    quote location: :keep do
+      @behaviour Ecto.Type
+
+      unquote(__generated_struct_and_metadata__(object_type, prefix))
+      unquote(__build_validator__(validate))
+      unquote(__generated_new_function__(validate))
+      unquote(__generated_parse_functions__(prefix, prefix_len, separator, validate))
+      unquote(__generated_ecto_type__())
+      unquote(__generated_ecto_cast__())
+      unquote(__generated_ecto_cast_binary__())
+      unquote(__generated_ecto_load__(storage_format, prefix))
+      unquote(__generated_storage_functions__(storage_format, prefix))
+      unquote(__generated_ecto_dump__())
+      unquote(__generated_ecto_comparison__())
+      unquote(__generated_protocols__(prefix, json_format))
+    end
+  end
+
+  defp __generated_struct_and_metadata__(object_type, prefix) do
+    quote location: :keep do
+      @type t :: %__MODULE__{id: binary(), __object_id__: true}
+
+      defstruct id: nil, __object_id__: true
+
+      @doc false
+      @spec object_type() :: String.t()
+      def object_type, do: unquote(object_type)
+
+      @doc false
+      @spec prefix() :: String.t()
+      def prefix, do: unquote(prefix)
+    end
+  end
+
+  defp __generated_new_function__(nil) do
+    quote location: :keep do
+      @doc """
+      Creates a new ObjectId with the given value.
+
+      ## Examples
+
+          iex> #{inspect(__MODULE__)}.new("abc-123")
+          {:ok, %#{inspect(__MODULE__)}{id: "abc-123"}}
+
+          iex> #{inspect(__MODULE__)}.new("")
+          {:error, :empty_value}
+      """
+      @spec new(binary()) :: {:ok, t()} | {:error, atom()}
+      def new(value) when is_binary(value) and value != "" do
+        {:ok, %__MODULE__{id: value}}
+      end
+
+      def new(value) when is_binary(value), do: {:error, :empty_value}
+
+      @doc """
+      Creates a new ObjectId with the given value, raising on failure.
+
+      ## Examples
+
+          iex> #{inspect(__MODULE__)}.new!("abc-123")
+          %#{inspect(__MODULE__)}{id: "abc-123"}
+      """
+      @spec new!(binary()) :: t()
+      def new!(value) when is_binary(value) do
+        case new(value) do
+          {:ok, id} ->
+            id
+
+          {:error, reason} ->
+            raise Trogon.ObjectId.ValidationError, module: __MODULE__, value: value, reason: reason
+        end
+      end
+    end
+  end
+
+  defp __generated_new_function__(_validate) do
+    quote location: :keep do
+      @doc """
+      Creates a new ObjectId with the given value.
+
+      Validates the value against the configured format.
+      Returns `{:ok, t()}` if valid, `{:error, reason}` otherwise.
+      """
+      @spec new(binary()) :: {:ok, t()} | {:error, atom()}
+      def new(value) when is_binary(value) and value != "" do
+        case validate_format(value) do
+          :ok -> {:ok, %__MODULE__{id: value}}
+          {:error, _} = error -> error
+        end
+      end
+
+      def new(value) when is_binary(value), do: {:error, :empty_value}
+
+      @doc """
+      Creates a new ObjectId with the given value, raising on failure.
+
+      Validates the value against the configured format.
+      Raises `Trogon.ObjectId.ValidationError` if invalid.
+      """
+      @spec new!(binary()) :: t()
+      def new!(value) when is_binary(value) do
+        case new(value) do
+          {:ok, id} ->
+            id
+
+          {:error, reason} ->
+            raise Trogon.ObjectId.ValidationError, module: __MODULE__, value: value, reason: reason
+        end
+      end
+    end
+  end
+
+  defp __generated_parse_functions__(prefix, prefix_len, separator, validate) do
+    quote location: :keep do
+      @doc """
+      Parses an ObjectId string.
+
+      The string must be in the format `#{unquote(prefix)}{id}`.
+
+      ## Examples
+
+          iex> #{inspect(__MODULE__)}.parse("#{unquote(prefix)}abc-123")
+          {:ok, %#{inspect(__MODULE__)}{id: "abc-123"}}
+
+          iex> #{inspect(__MODULE__)}.parse("invalid")
+          {:error, :invalid_format}
+
+          iex> #{inspect(__MODULE__)}.parse("wrong#{unquote(separator)}abc-123")
+          {:error, :invalid_format}
+      """
+      @spec parse(String.t()) :: {:ok, t()} | {:error, atom()}
+      def parse(string) when is_binary(string) do
+        Trogon.ObjectId.parse(
+          __MODULE__,
+          unquote(prefix),
+          unquote(prefix_len),
+          string,
+          unquote(__validator_ref__(validate))
+        )
+      end
+
+      @doc """
+      Parses an ObjectId string, raising on failure.
+
+      Same as `parse/1` but raises `ArgumentError` if the string is invalid.
+
+      ## Examples
+
+          iex> #{inspect(__MODULE__)}.parse!("#{unquote(prefix)}abc-123")
+          %#{inspect(__MODULE__)}{id: "abc-123"}
+
+          iex> #{inspect(__MODULE__)}.parse!("invalid")
+          ** (ArgumentError) invalid #{inspect(__MODULE__)}: "invalid"
+      """
+      @spec parse!(String.t()) :: t()
+      def parse!(string) when is_binary(string) do
+        case parse(string) do
+          {:ok, id} ->
+            id
+
+          {:error, reason} ->
+            raise Trogon.ObjectId.ValidationError, module: __MODULE__, value: string, reason: reason
+        end
+      end
+    end
+  end
+
+  defp __validator_ref__(nil), do: nil
+  defp __validator_ref__(_format), do: quote(do: &validate_format/1)
+
+  defp __build_validator__(nil), do: nil
+
+  defp __build_validator__(:uuid) do
+    quote location: :keep do
+      defp validate_format(value) do
+        case Uniq.UUID.parse(value) do
+          {:ok, _} -> :ok
+          {:error, _} -> {:error, :invalid_uuid}
+        end
+      end
+    end
+  end
+
+  defp __build_validator__(:integer) do
+    quote location: :keep do
+      defp validate_format(value) do
+        case Integer.parse(value) do
+          {_, ""} -> :ok
+          _ -> {:error, :invalid_integer}
+        end
+      end
+    end
+  end
+
+  defp __build_validator__({module, function}) do
+    quote location: :keep do
+      defp validate_format(value), do: unquote(module).unquote(function)(value)
+    end
+  end
+
+  defp __generated_ecto_type__ do
+    quote location: :keep do
+      @impl Ecto.Type
+      @spec type() :: :string
+      def type, do: :string
+    end
+  end
+
+  defp __generated_ecto_cast__ do
+    quote location: :keep do
+      @impl Ecto.Type
+      @spec cast(any()) :: {:ok, t() | nil} | :error
+      def cast(nil), do: {:ok, nil}
+      def cast(""), do: {:ok, nil}
+      def cast(%__MODULE__{id: ""}), do: :error
+      def cast(%__MODULE__{id: nil}), do: :error
+      def cast(%__MODULE__{id: id} = value) when is_binary(id), do: {:ok, value}
+      def cast(value) when is_binary(value), do: cast_binary(value)
+      def cast(_), do: :error
+    end
+  end
+
+  defp __generated_ecto_cast_binary__ do
+    quote location: :keep do
+      @spec cast_binary(binary()) :: {:ok, t()} | :error
+      defp cast_binary(value) do
+        case parse(value) do
+          {:ok, _} = ok -> ok
+          {:error, _} -> :error
+        end
+      end
+    end
+  end
+
+  defp __generated_ecto_load__(storage_format, prefix) do
+    quote location: :keep do
+      @impl Ecto.Type
+      @spec load(any()) :: {:ok, t() | nil} | :error
+      def load(nil), do: {:ok, nil}
+      def load(""), do: {:ok, nil}
+
+      def load(value) when is_binary(value) do
+        full_value = Trogon.ObjectId.with_prefix(value, unquote(storage_format), unquote(prefix))
+
+        case parse(full_value) do
+          {:ok, typeid} -> {:ok, typeid}
+          {:error, _} -> :error
+        end
+      end
+
+      def load(_), do: :error
+    end
+  end
+
+  defp __generated_storage_functions__(storage_format, prefix) do
+    storage_example_output =
+      if storage_format == :full, do: inspect(prefix <> "abc-123"), else: inspect("abc-123")
+
+    quote location: :keep do
+      @doc """
+      Converts an ObjectId struct to a storage format string.
+
+      ## Examples
+
+          iex> #{inspect(__MODULE__)}.to_storage(%#{inspect(__MODULE__)}{id: "abc-123"})
+          #{unquote(storage_example_output)}
+      """
+      @spec to_storage(t()) :: String.t()
+      def to_storage(%__MODULE__{id: id}) when is_binary(id) and id != "" do
+        Trogon.ObjectId.format(unquote(storage_format), unquote(prefix), id)
+      end
+    end
+  end
+
+  defp __generated_ecto_dump__ do
+    quote location: :keep do
+      @impl Ecto.Type
+      @spec dump(any()) :: {:ok, String.t() | nil} | :error
+      def dump(nil), do: {:ok, nil}
+      def dump(%__MODULE__{id: ""}), do: :error
+      def dump(%__MODULE__{id: nil}), do: :error
+      def dump(%__MODULE__{id: id} = v) when is_binary(id), do: {:ok, to_storage(v)}
+      def dump(_), do: :error
+    end
+  end
+
+  defp __generated_ecto_comparison__ do
+    quote location: :keep do
+      @impl Ecto.Type
+      @spec equal?(any(), any()) :: boolean()
+      def equal?(%__MODULE__{id: a}, %__MODULE__{id: b}), do: a == b
+      def equal?(_, _), do: false
+
+      @impl Ecto.Type
+      @spec embed_as(atom()) :: :self
+      def embed_as(_format), do: :self
+    end
+  end
+
+  defp __generated_protocols__(prefix, json_format) do
+    quote location: :keep do
+      defimpl String.Chars do
+        @moduledoc false
+        def to_string(%@for{id: id}) when is_binary(id) do
+          "#{unquote(prefix)}#{id}"
+        end
+      end
+
+      if Code.ensure_loaded?(Jason.Encoder) do
+        defimpl Jason.Encoder do
+          @moduledoc false
+          def encode(%@for{id: id}, opts) when is_binary(id) do
+            value = Trogon.ObjectId.format(unquote(json_format), unquote(prefix), id)
+            Jason.Encode.string(value, opts)
+          end
+        end
+      end
+    end
+  end
+
+  @doc false
+  @spec parse(module(), String.t(), non_neg_integer(), String.t(), nil | (String.t() -> :ok | {:error, atom()})) ::
+          {:ok, struct()} | {:error, atom()}
+  def parse(module, prefix, prefix_len, string, validate_format) do
+    case string do
+      <<^prefix::binary-size(prefix_len), suffix::binary>> when suffix != "" ->
+        validate_and_build(module, suffix, validate_format)
+
+      _ ->
+        {:error, :invalid_format}
+    end
+  end
+
+  defp validate_and_build(module, id, nil), do: {:ok, struct(module, id: id)}
+
+  defp validate_and_build(module, id, validate_format) do
+    case validate_format.(id) do
+      :ok -> {:ok, struct(module, id: id)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc false
+  @spec format(:full | :drop_prefix, String.t(), String.t()) :: String.t()
+  def format(:full, prefix, id), do: prefix <> id
+  def format(:drop_prefix, _prefix, id), do: id
+
+  @doc false
+  @spec with_prefix(String.t(), :full | :drop_prefix, String.t()) :: String.t()
+  def with_prefix(value, :full, _prefix), do: value
+  def with_prefix(value, :drop_prefix, prefix), do: prefix <> value
+
+  defp resolve_proto_options(opts, caller) do
+    case Keyword.pop(opts, :proto) do
+      {nil, opts} ->
+        opts
+
+      {{mod, val}, opts} ->
+        mod = Macro.expand(mod, caller)
+        {object_type, separator} = extract_proto_options(mod, val)
+
+        opts
+        |> Keyword.put_new(:object_type, object_type)
+        |> Keyword.put_new(:separator, separator)
+    end
+  end
+
+  defp extract_proto_options(enum_module, version) do
+    binary =
+      ProtoExtension.find_enum_value_extension!(
+        enum_module,
+        version,
+        @proto_extension_tag,
+        @proto_extension_name
+      )
+
+    opts = ObjectIdEnumValueOptions.decode(binary)
+
+    if opts.object_type == "" do
+      raise ArgumentError,
+            "object_type is required for #{inspect(version)} but was empty."
+    end
+
+    separator = if opts.separator, do: opts.separator, else: @default_separator
+
+    {opts.object_type, separator}
+  end
+end

--- a/apps/trogon_object_id/lib/trogon/object_id/proto_extension.ex
+++ b/apps/trogon_object_id/lib/trogon/object_id/proto_extension.ex
@@ -1,0 +1,41 @@
+defmodule Trogon.ObjectId.ProtoExtension do
+  @moduledoc false
+
+  @spec find_enum_value_extension!(module(), atom(), non_neg_integer(), String.t()) :: binary()
+  def find_enum_value_extension!(enum_module, value, tag, extension_name) do
+    desc = enum_module.descriptor()
+    value_name = Atom.to_string(value)
+    value_desc = Enum.find(desc.value, &(&1.name == value_name))
+
+    case value_desc do
+      nil ->
+        available = Enum.map(desc.value, &String.to_atom(&1.name))
+
+        raise ArgumentError,
+              "Enum value #{inspect(value)} not found. Available values: #{inspect(available)}"
+
+      %{options: nil} ->
+        raise ArgumentError,
+              "No options found for #{inspect(value)}. " <>
+                "Add (#{extension_name}) to the proto enum value."
+
+      %{options: %{__unknown_fields__: fields}} ->
+        case find_field(fields, tag) do
+          nil ->
+            raise ArgumentError,
+                  "No #{extension_name} extension found for #{inspect(value)}. " <>
+                    "Add (#{extension_name}) to the proto enum value."
+
+          binary ->
+            binary
+        end
+    end
+  end
+
+  defp find_field(fields, tag) do
+    case Enum.find(fields, &(elem(&1, 0) == tag)) do
+      {_, _, binary} -> binary
+      nil -> nil
+    end
+  end
+end

--- a/apps/trogon_object_id/lib/trogon/object_id/validation_error.ex
+++ b/apps/trogon_object_id/lib/trogon/object_id/validation_error.ex
@@ -1,0 +1,11 @@
+defmodule Trogon.ObjectId.ValidationError do
+  @moduledoc """
+  Raised when an ObjectId value is invalid.
+  """
+  defexception [:module, :value, :reason]
+
+  @impl true
+  def message(%{module: module, value: value, reason: reason}) do
+    "invalid #{inspect(module)} value: #{inspect(value)} (#{reason})"
+  end
+end

--- a/apps/trogon_object_id/lib/trogon/union_object_id.ex
+++ b/apps/trogon_object_id/lib/trogon/union_object_id.ex
@@ -1,0 +1,401 @@
+defmodule Trogon.UnionObjectId do
+  @moduledoc """
+  Discriminated union type that can hold any of multiple `Trogon.ObjectId` types.
+  """
+
+  @using_opts_schema NimbleOptions.new!(
+                       types: [
+                         type: {:list, :atom},
+                         required: true,
+                         doc: "List of ObjectId modules that can be held by this union."
+                       ]
+                     )
+
+  @doc """
+  Defines a union type that can hold any of the specified ObjectId types.
+
+  Creates a discriminated union that combines multiple ObjectId types into a single field.
+  The prefix of each ObjectId determines which type it is when parsing from storage.
+
+  ## Options
+
+  #{NimbleOptions.docs(@using_opts_schema)}
+
+  ## Usage
+
+  First, define individual ObjectId types:
+
+      defmodule MyApp.TenantId do
+        use Trogon.ObjectId, object_type: "tenant"
+      end
+
+      defmodule MyApp.SystemId do
+        use Trogon.ObjectId, object_type: "system"
+      end
+
+  Then, create a union that combines them:
+
+      defmodule MyApp.PrincipalId do
+        use Trogon.UnionObjectId,
+          types: [MyApp.TenantId, MyApp.SystemId]
+      end
+
+  Use the union:
+
+      iex> tenant_id = MyApp.TenantId.new("abc-123")
+      iex> principal = MyApp.PrincipalId.new(tenant_id)
+      %MyApp.PrincipalId{id: %MyApp.TenantId{id: "abc-123"}}
+
+      iex> MyApp.PrincipalId.parse("tenant_abc-123")
+      {:ok, %MyApp.PrincipalId{id: %MyApp.TenantId{id: "abc-123"}}}
+
+      iex> to_string(principal)
+      "tenant_abc-123"
+
+  ## Type Safety
+
+  The union preserves the type of the inner ObjectId, so you can pattern match to determine
+  which variant you have:
+
+      iex> case principal.id do
+      ...>   %MyApp.TenantId{} -> "Got a tenant!"
+      ...>   %MyApp.SystemId{} -> "Got a system!"
+      ...> end
+      "Got a tenant!"
+
+  ## Storage Format
+
+  The union stores the complete prefixed string (e.g., `"tenant_abc-123"`). The prefix is
+  essential for type identification when parsing. Without it, the union cannot determine
+  which type to deserialize to.
+
+      iex> MyApp.PrincipalId.to_storage(principal)
+      "tenant_abc-123"
+
+  ## Ecto Integration
+
+  The union implements `Ecto.Type`, so you can use it directly in Ecto schemas:
+
+      defmodule MyApp.Event do
+        use Ecto.Schema
+
+        schema "events" do
+          field :actor_id, MyApp.PrincipalId
+        end
+      end
+
+  ## Compile-Time Validation
+
+  The macro validates your union definition at compile time:
+
+  - **Non-empty types list**: At least one ObjectId type must be provided
+  - **No exact prefix duplicates**: No two types can have the same prefix
+
+  > #### Warning {: .warning}
+  >
+  > **Prefix Overlaps Are Not Caught at Compile Time**
+  >
+  > Compile-time validation only catches **exact prefix duplicates**, not partial overlaps.
+  > If one prefix is a substring of another, the shorter prefix will match first during parsing,
+  > causing silent type mismatches.
+  >
+  > **Example of the Problem:**
+  >
+  > ```elixir
+  > defmodule AcmeId do
+  >   use Trogon.ObjectId, object_type: "acme"  # prefix: "acme_"
+  > end
+  >
+  > defmodule AcmeAdminId do
+  >   use Trogon.ObjectId, object_type: "acme_admin"  # prefix: "acme_admin_"
+  > end
+  >
+  > defmodule PrincipalId do
+  >   use Trogon.UnionObjectId, types: [AcmeId, AcmeAdminId]
+  > end
+  >
+  > # This compiles but gives the wrong result:
+  > PrincipalId.parse("acme_admin_xyz")
+  > # => {:ok, %PrincipalId{id: %AcmeId{id: "admin_xyz"}}}  # WRONG!
+  > # Should be: %PrincipalId{id: %AcmeAdminId{id: "xyz"}}
+  > ```
+  >
+  > **How to Avoid:**
+  >
+  > Design ObjectId prefixes to be semantically distinct and non-overlapping:
+  > - Good: `"tenant"`, `"system"`, `"service"`
+  > - Bad: `"acme"`, `"acme_admin"` (one is substring of other)
+  > - Bad: `"app"`, `"apple"` (one is substring of other)
+  """
+  defmacro __using__(opts) do
+    # Expand module aliases before validation
+    types =
+      opts
+      |> Keyword.fetch!(:types)
+      |> Enum.map(&Macro.expand(&1, __CALLER__))
+
+    opts = Keyword.put(opts, :types, types)
+    opts = NimbleOptions.validate!(opts, @using_opts_schema)
+    types = Keyword.fetch!(opts, :types)
+
+    if Enum.empty?(types) do
+      raise CompileError,
+        description: "UnionObjectId types list cannot be empty. Provide at least one ObjectId type."
+    end
+
+    # Compile-time check: ensure no overlapping prefixes
+    validate_no_prefix_collisions(types)
+
+    quote location: :keep do
+      @behaviour Ecto.Type
+
+      @type t :: %__MODULE__{id: struct()}
+
+      defstruct [:id]
+
+      unquote(__generated_new_functions__(types))
+      unquote(__generated_parse_functions__(types))
+      unquote(__generated_storage_functions__(types))
+      unquote(__generated_ecto_cast__())
+      unquote(__generated_ecto_load__())
+      unquote(__generated_ecto_dump__())
+      unquote(__generated_ecto_comparison__())
+      unquote(__generated_protocols__())
+    end
+  end
+
+  defp __generated_new_functions__(types) do
+    quote location: :keep do
+      @doc """
+      Wraps an existing ObjectId struct into the union.
+
+      The passed struct must be one of the union's types.
+
+      ## Examples
+
+          iex> obj_id = #{unquote(Enum.at(types, 0))}.new("abc-123")
+          iex> #{inspect(__MODULE__)}.new(obj_id)
+          %#{inspect(__MODULE__)}{id: %#{unquote(Enum.at(types, 0))}{id: "abc-123"}}
+      """
+      unquote(
+        for module <- types do
+          quote do
+            @spec new(unquote(module).t()) :: t()
+            def new(%unquote(module){} = id), do: %__MODULE__{id: id}
+          end
+        end
+      )
+    end
+  end
+
+  defp __generated_parse_functions__(types) do
+    quote location: :keep do
+      @doc """
+      Parses a string by trying each underlying type's parse function.
+
+      The string must be in a format recognized by one of the union's types.
+
+      ## Examples
+
+          iex> #{inspect(__MODULE__)}.parse("#{unquote(Enum.at(types, 0)).prefix()}abc-123")
+          {:ok, %#{inspect(__MODULE__)}{id: %#{unquote(Enum.at(types, 0))}{id: "abc-123"}}}
+
+          iex> #{inspect(__MODULE__)}.parse("invalid")
+          {:error, :invalid_format}
+      """
+      @spec parse(String.t()) :: {:ok, t()} | {:error, atom()}
+      def parse(""), do: {:error, :invalid_format}
+
+      unquote(
+        for module <- types do
+          prefix = module.prefix()
+
+          quote do
+            def parse(unquote(prefix) <> id) when id != "" do
+              case unquote(module).new(id) do
+                {:ok, inner} -> {:ok, %__MODULE__{id: inner}}
+                {:error, _} = error -> error
+              end
+            end
+          end
+        end
+      )
+
+      def parse(_), do: {:error, :invalid_format}
+
+      @doc """
+      Parses a string by trying each underlying type's parse function, raising on failure.
+
+      Same as `parse/1` but raises `ArgumentError` if the string is invalid.
+
+      ## Examples
+
+          iex> #{inspect(__MODULE__)}.parse!("#{unquote(Enum.at(types, 0)).prefix()}abc-123")
+          %#{inspect(__MODULE__)}{id: %#{unquote(Enum.at(types, 0))}{id: "abc-123"}}
+
+          iex> #{inspect(__MODULE__)}.parse!("invalid")
+          ** (ArgumentError) invalid #{inspect(__MODULE__)}: "invalid"
+      """
+      @spec parse!(String.t()) :: t()
+      def parse!(string) when is_binary(string) do
+        Trogon.UnionObjectId.parse!(__MODULE__, string)
+      end
+    end
+  end
+
+  defp __generated_storage_functions__(types) do
+    quote location: :keep do
+      @doc """
+      Converts the union to a storage string.
+
+      Uses the inner ObjectId's to_string representation, which includes its full prefix.
+
+      ## Examples
+
+          iex> obj_id = #{unquote(Enum.at(types, 0))}.new("abc-123")
+          iex> union = #{inspect(__MODULE__)}.new(obj_id)
+          iex> #{inspect(__MODULE__)}.to_storage(union)
+          "#{unquote(Enum.at(types, 0)).prefix()}abc-123"
+      """
+      @spec to_storage(t()) :: String.t()
+      def to_storage(%__MODULE__{id: id}) when is_struct(id), do: Kernel.to_string(id)
+    end
+  end
+
+  defp __generated_ecto_cast__() do
+    quote location: :keep do
+      @impl Ecto.Type
+      @spec type() :: :string
+      def type, do: :string
+
+      @impl Ecto.Type
+      @spec cast(any()) :: {:ok, t() | nil} | :error
+      def cast(nil), do: {:ok, nil}
+      def cast(""), do: {:ok, nil}
+      def cast(%__MODULE__{id: id} = value) when is_struct(id), do: {:ok, value}
+
+      def cast(value) when is_binary(value) do
+        Trogon.UnionObjectId.ecto_parse(__MODULE__, value)
+      end
+
+      def cast(_), do: :error
+    end
+  end
+
+  defp __generated_ecto_load__() do
+    quote location: :keep do
+      @impl Ecto.Type
+      @spec load(any()) :: {:ok, t() | nil} | :error
+      def load(nil), do: {:ok, nil}
+      def load(""), do: {:ok, nil}
+
+      def load(value) when is_binary(value) do
+        Trogon.UnionObjectId.ecto_parse(__MODULE__, value)
+      end
+
+      def load(_), do: :error
+    end
+  end
+
+  defp __generated_ecto_dump__() do
+    quote location: :keep do
+      @impl Ecto.Type
+      @spec dump(any()) :: {:ok, String.t() | nil} | :error
+      def dump(nil), do: {:ok, nil}
+      def dump(%__MODULE__{id: id} = value) when is_struct(id), do: {:ok, to_storage(value)}
+      def dump(_), do: :error
+    end
+  end
+
+  defp __generated_ecto_comparison__() do
+    quote location: :keep do
+      @impl Ecto.Type
+      @spec equal?(any(), any()) :: boolean()
+      def equal?(%__MODULE__{id: a}, %__MODULE__{id: b}), do: a == b
+      def equal?(_, _), do: false
+
+      @impl Ecto.Type
+      @spec embed_as(atom()) :: :self
+      def embed_as(_format), do: :self
+    end
+  end
+
+  defp __generated_protocols__() do
+    quote location: :keep do
+      defimpl String.Chars do
+        @moduledoc false
+        def to_string(%@for{id: id}), do: Kernel.to_string(id)
+      end
+
+      if Code.ensure_loaded?(Jason.Encoder) do
+        defimpl Jason.Encoder do
+          @moduledoc false
+          def encode(%@for{id: id}, opts) do
+            Jason.Encoder.encode(id, opts)
+          end
+        end
+      end
+    end
+  end
+
+  @doc false
+  @spec parse!(module(), String.t()) :: struct()
+  def parse!(module, string) do
+    case module.parse(string) do
+      {:ok, union} -> union
+      {:error, reason} -> raise Trogon.ObjectId.ValidationError, module: module, value: string, reason: reason
+    end
+  end
+
+  @doc false
+  @spec ecto_parse(module(), String.t()) :: {:ok, struct()} | :error
+  def ecto_parse(module, value) do
+    case module.parse(value) do
+      {:ok, union} -> {:ok, union}
+      {:error, _} -> :error
+    end
+  end
+
+  defp validate_no_prefix_collisions(types) do
+    types
+    |> build_prefix_map()
+    |> check_duplicate_prefixes()
+  end
+
+  @doc false
+  defp build_prefix_map(types) do
+    types
+    |> Enum.map(&module_with_prefix/1)
+    |> Enum.group_by(&elem(&1, 1))
+  end
+
+  @doc false
+  defp module_with_prefix(module) do
+    {module, module.prefix()}
+  end
+
+  @doc false
+  defp check_duplicate_prefixes(prefixes_by_type) do
+    Enum.each(prefixes_by_type, &check_prefix_collision/1)
+  end
+
+  @doc false
+  defp check_prefix_collision({prefix, modules}) do
+    if length(modules) > 1 do
+      raise_prefix_collision_error(prefix, modules)
+    end
+  end
+
+  @doc false
+  defp raise_prefix_collision_error(prefix, modules) do
+    module_names = format_module_names(modules)
+
+    raise CompileError,
+      description: "UnionObjectId prefix collision: #{inspect(prefix)} is used by multiple types: #{module_names}"
+  end
+
+  @doc false
+  defp format_module_names(modules) do
+    Enum.map_join(modules, ", ", &elem(&1, 0))
+  end
+end

--- a/apps/trogon_object_id/mix.exs
+++ b/apps/trogon_object_id/mix.exs
@@ -1,0 +1,130 @@
+defmodule Trogon.ObjectId.MixProject do
+  use Mix.Project
+
+  @app :trogon_object_id
+  @version "0.0.1"
+  @elixir_version "~> 1.18"
+  @source_url "https://github.com/straw-hat-team/beam-monorepo"
+
+  def project do
+    [
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      name: "Trogon.ObjectId",
+      description: "Type-safe, domain-specific object IDs with Ecto integration",
+      app: @app,
+      version: @version,
+      elixir: @elixir_version,
+      elixirc_paths: elixirc_paths(Mix.env()),
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      aliases: aliases(),
+      test_coverage: test_coverage(),
+      package: package(),
+      docs: docs(),
+      dialyzer: dialyzer()
+    ]
+  end
+
+  def cli do
+    [preferred_envs: preferred_cli_env()]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:uniq, "~> 0.1"},
+      {:jason, "~> 1.2", optional: true},
+      {:ecto, "~> 3.6"},
+      {:nimble_options, "~> 1.0"},
+      {:protobuf, "~> 0.16", optional: true},
+      trogon_proto_dep(),
+
+      # Tools
+      {:dialyxir, ">= 0.0.0", only: [:dev], runtime: false},
+      {:credo, ">= 0.0.0", only: [:dev, :test], runtime: false},
+      {:excoveralls, ">= 0.0.0", only: [:test], runtime: false},
+      {:ex_doc, ">= 0.0.0", only: [:dev], runtime: false}
+    ]
+  end
+
+  defp trogon_proto_dep do
+    if System.get_env("MIX_IN_UMBRELLA_DEPS") == "false" do
+      {:trogon_proto, "~> 0.4", optional: true}
+    else
+      {:trogon_proto, in_umbrella: true}
+    end
+  end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
+  defp aliases do
+    [
+      test: ["test --trace"]
+    ]
+  end
+
+  defp test_coverage do
+    [tool: ExCoveralls]
+  end
+
+  defp preferred_cli_env do
+    [
+      "coveralls.html": :test,
+      "coveralls.json": :test,
+      "coveralls.github": :test,
+      coveralls: :test
+    ]
+  end
+
+  defp dialyzer do
+    [
+      plt_core_path: "priv/plts",
+      ignore_warnings: ".dialyzer_ignore.exs"
+    ]
+  end
+
+  defp package do
+    [
+      name: @app,
+      files: [
+        ".formatter.exs",
+        "lib",
+        "mix.exs",
+        "README*",
+        "LICENSE*"
+      ],
+      maintainers: ["Yordis Prieto"],
+      licenses: ["MIT"],
+      links: %{
+        "GitHub" => @source_url
+      }
+    ]
+  end
+
+  defp docs do
+    [
+      main: "readme",
+      homepage_url: @source_url,
+      source_url_pattern: "#{@source_url}/blob/#{@app}@v#{@version}/apps/#{@app}/%{path}#L%{line}",
+      skip_undefined_reference_warnings_on: ["CHANGELOG.md"],
+      extras: [
+        "README.md",
+        "CHANGELOG.md"
+      ],
+      groups_for_extras: [
+        "How-to": ~r/docs\/how-to\/.?/,
+        Explanations: ~r/docs\/explanations\/.?/,
+        References: ~r/docs\/references\/.?/
+      ]
+    ]
+  end
+end

--- a/apps/trogon_object_id/test/proto/acme/object_type.proto
+++ b/apps/trogon_object_id/test/proto/acme/object_type.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package acme.type.v1;
+
+import "trogon/object_id/v1alpha1/options.proto";
+
+enum ObjectType {
+  OBJECT_TYPE_UNSPECIFIED = 0;
+  OBJECT_TYPE_TICKET = 1 [(trogon.object_id.v1alpha1.enum_value).object_type = "ticket"];
+  OBJECT_TYPE_WORKSPACE = 2 [(trogon.object_id.v1alpha1.enum_value) = {
+    object_type: "workspace",
+    separator: "#"
+  }];
+}

--- a/apps/trogon_object_id/test/support/proto/acme/object_type.pb.ex
+++ b/apps/trogon_object_id/test/support/proto/acme/object_type.pb.ex
@@ -1,0 +1,62 @@
+defmodule Acme.Type.V1.ObjectType do
+  @moduledoc false
+
+  use Protobuf,
+    enum: true,
+    full_name: "acme.type.v1.ObjectType",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.EnumDescriptorProto{
+      name: "ObjectType",
+      value: [
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "OBJECT_TYPE_UNSPECIFIED",
+          number: 0,
+          options: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "OBJECT_TYPE_TICKET",
+          number: 1,
+          options: %Google.Protobuf.EnumValueOptions{
+            deprecated: false,
+            features: nil,
+            debug_redact: false,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [{870_010, 2, <<10, 6, 116, 105, 99, 107, 101, 116>>}]
+          },
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "OBJECT_TYPE_WORKSPACE",
+          number: 2,
+          options: %Google.Protobuf.EnumValueOptions{
+            deprecated: false,
+            features: nil,
+            debug_redact: false,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [
+              {870_010, 2, <<10, 9, 119, 111, 114, 107, 115, 112, 97, 99, 101, 18, 1, 35>>}
+            ]
+          },
+          __unknown_fields__: []
+        }
+      ],
+      options: nil,
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field :OBJECT_TYPE_UNSPECIFIED, 0
+  field :OBJECT_TYPE_TICKET, 1
+  field :OBJECT_TYPE_WORKSPACE, 2
+end

--- a/apps/trogon_object_id/test/support/test_support.ex
+++ b/apps/trogon_object_id/test/support/test_support.ex
@@ -1,0 +1,154 @@
+defmodule Trogon.ObjectId.TestSupport do
+  @moduledoc false
+
+  defmodule UserId do
+    @moduledoc false
+    use Trogon.ObjectId, object_type: "user"
+  end
+
+  defmodule OrderId do
+    @moduledoc false
+    use Trogon.ObjectId, object_type: "order"
+  end
+
+  defmodule AccountId do
+    @moduledoc false
+    use Trogon.ObjectId, object_type: "account"
+  end
+
+  defmodule CustomSeparatorId do
+    @moduledoc false
+    use Trogon.ObjectId, object_type: "custom", separator: "#"
+  end
+
+  defmodule FullStorageId do
+    @moduledoc false
+    use Trogon.ObjectId, object_type: "full", storage_format: :full
+  end
+
+  defmodule DropPrefixId do
+    @moduledoc false
+    use Trogon.ObjectId, object_type: "drop", storage_format: :drop_prefix
+  end
+
+  defmodule TypeWithSeparatorId do
+    @moduledoc false
+    use Trogon.ObjectId, object_type: "my_user", separator: "_"
+  end
+
+  defmodule SimpleTypeId do
+    @moduledoc false
+    use Trogon.ObjectId, object_type: "myuser"
+  end
+
+  defmodule DashTypeId do
+    @moduledoc false
+    use Trogon.ObjectId, object_type: "my-user", separator: "_"
+  end
+
+  defmodule JsonDropPrefixId do
+    @moduledoc false
+    use Trogon.ObjectId,
+      object_type: "jsondrop",
+      storage_format: :full,
+      json_format: :drop_prefix
+  end
+
+  defmodule StorageDropJsonFullId do
+    @moduledoc false
+    use Trogon.ObjectId,
+      object_type: "mixed",
+      storage_format: :drop_prefix,
+      json_format: :full
+  end
+
+  defmodule TenantId do
+    @moduledoc false
+    use Trogon.ObjectId, object_type: "tenant"
+  end
+
+  defmodule SystemId do
+    @moduledoc false
+    use Trogon.ObjectId, object_type: "system"
+  end
+
+  defmodule ServiceId do
+    @moduledoc false
+    use Trogon.ObjectId, object_type: "service"
+  end
+
+  defmodule ContextId do
+    @moduledoc false
+    use Trogon.UnionObjectId, types: [TenantId, SystemId]
+  end
+
+  defmodule PrincipalId do
+    @moduledoc false
+    use Trogon.UnionObjectId, types: [TenantId, SystemId, ServiceId]
+  end
+
+  defmodule AmbiguousPrefixIdA do
+    @moduledoc false
+    use Trogon.ObjectId, object_type: "a", separator: "bc_"
+  end
+
+  defmodule AmbiguousPrefixIdB do
+    @moduledoc false
+    use Trogon.ObjectId, object_type: "abc", separator: "_"
+  end
+
+  defmodule UuidFormatId do
+    @moduledoc false
+    use Trogon.ObjectId, object_type: "uuid", validate: :uuid
+  end
+
+  defmodule IntegerFormatId do
+    @moduledoc false
+    use Trogon.ObjectId, object_type: "int", validate: :integer
+  end
+
+  defmodule UuidDropPrefixId do
+    @moduledoc false
+    use Trogon.ObjectId,
+      object_type: "uuiddrop",
+      storage_format: :drop_prefix,
+      validate: :uuid
+  end
+
+  defmodule ProtoTicketId do
+    @moduledoc false
+    use Trogon.ObjectId,
+      proto: {Acme.Type.V1.ObjectType, :OBJECT_TYPE_TICKET}
+  end
+
+  defmodule ProtoWorkspaceId do
+    @moduledoc false
+    use Trogon.ObjectId,
+      proto: {Acme.Type.V1.ObjectType, :OBJECT_TYPE_WORKSPACE},
+      storage_format: :drop_prefix
+  end
+
+  defmodule CustomValidator do
+    @moduledoc false
+
+    def check(value) do
+      if String.starts_with?(value, "valid-") do
+        :ok
+      else
+        {:error, :invalid_custom_format}
+      end
+    end
+  end
+
+  defmodule CustomFormatId do
+    @moduledoc false
+    use Trogon.ObjectId,
+      object_type: "custom_fmt",
+      validate: {Trogon.ObjectId.TestSupport.CustomValidator, :check}
+  end
+
+  defmodule ValidatedUnionId do
+    @moduledoc false
+    use Trogon.UnionObjectId, types: [UuidFormatId, TenantId]
+  end
+end

--- a/apps/trogon_object_id/test/test_helper.exs
+++ b/apps/trogon_object_id/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/apps/trogon_object_id/test/trogon/object_id_test.exs
+++ b/apps/trogon_object_id/test/trogon/object_id_test.exs
@@ -1,0 +1,674 @@
+defmodule Trogon.ObjectIdTest do
+  use ExUnit.Case
+
+  import Trogon.ObjectId
+
+  alias Trogon.ObjectId.TestSupport
+
+  @test_uuid "test-value-1"
+  @test_uuid_2 "test-value-2"
+
+  describe "object_type/0" do
+    test "returns the configured type" do
+      assert TestSupport.UserId.object_type() == "user"
+      assert TestSupport.OrderId.object_type() == "order"
+      assert TestSupport.AccountId.object_type() == "account"
+    end
+
+    test "returns type even when it contains the separator character" do
+      assert TestSupport.TypeWithSeparatorId.object_type() == "my_user"
+    end
+  end
+
+  describe "prefix/0" do
+    test "returns the full prefix (type + separator)" do
+      assert TestSupport.UserId.prefix() == "user_"
+      assert TestSupport.OrderId.prefix() == "order_"
+    end
+
+    test "returns prefix with custom separator" do
+      assert TestSupport.CustomSeparatorId.prefix() == "custom#"
+    end
+
+    test "returns prefix when type contains the separator character" do
+      assert TestSupport.TypeWithSeparatorId.prefix() == "my_user_"
+    end
+  end
+
+  describe "new/1" do
+    test "returns {:ok, struct} for valid value" do
+      assert {:ok, %TestSupport.UserId{id: @test_uuid}} = TestSupport.UserId.new(@test_uuid)
+    end
+
+    test "returns {:error, :empty_value} for empty string" do
+      assert {:error, :empty_value} = TestSupport.UserId.new("")
+    end
+
+    test "returns {:ok, struct} with distinct struct types" do
+      assert {:ok, user_id} = TestSupport.UserId.new(@test_uuid)
+      assert {:ok, order_id} = TestSupport.OrderId.new(@test_uuid)
+
+      assert is_struct(user_id, TestSupport.UserId)
+      assert is_struct(order_id, TestSupport.OrderId)
+      assert not is_struct(user_id, TestSupport.OrderId)
+    end
+
+    test "validates value when validate: :uuid is configured" do
+      valid_uuid = "550e8400-e29b-41d4-a716-446655440000"
+      assert {:ok, %TestSupport.UuidFormatId{id: ^valid_uuid}} = TestSupport.UuidFormatId.new(valid_uuid)
+      assert {:error, :invalid_uuid} = TestSupport.UuidFormatId.new("not-a-uuid")
+    end
+
+    test "validates value when validate: :integer is configured" do
+      assert {:ok, %TestSupport.IntegerFormatId{id: "12345"}} = TestSupport.IntegerFormatId.new("12345")
+      assert {:error, :invalid_integer} = TestSupport.IntegerFormatId.new("abc")
+    end
+
+    test "validates value with custom validator" do
+      assert {:ok, %TestSupport.CustomFormatId{id: "valid-123"}} = TestSupport.CustomFormatId.new("valid-123")
+      assert {:error, :invalid_custom_format} = TestSupport.CustomFormatId.new("invalid-value")
+    end
+
+    test "skips validation when no validate option" do
+      assert {:ok, %TestSupport.UserId{id: "anything-goes"}} = TestSupport.UserId.new("anything-goes")
+    end
+  end
+
+  describe "new!/1" do
+    test "returns struct for valid value" do
+      assert %TestSupport.UserId{id: @test_uuid} = TestSupport.UserId.new!(@test_uuid)
+    end
+
+    test "raises ValidationError for empty string" do
+      assert_raise Trogon.ObjectId.ValidationError, ~r/empty_value/, fn ->
+        TestSupport.UserId.new!("")
+      end
+    end
+
+    test "raises ValidationError when validation fails" do
+      assert_raise Trogon.ObjectId.ValidationError, ~r/invalid_uuid/, fn ->
+        TestSupport.UuidFormatId.new!("not-a-uuid")
+      end
+    end
+
+    test "returns struct when validation passes" do
+      valid_uuid = "550e8400-e29b-41d4-a716-446655440000"
+      assert %TestSupport.UuidFormatId{id: ^valid_uuid} = TestSupport.UuidFormatId.new!(valid_uuid)
+    end
+  end
+
+  describe "parse/1" do
+    test "parses a valid string" do
+      typeid = TestSupport.UserId.new!(@test_uuid)
+      typeid_string = to_string(typeid)
+
+      assert {:ok, parsed} = TestSupport.UserId.parse(typeid_string)
+      assert parsed.id == typeid.id
+    end
+
+    test "returns error for invalid format" do
+      assert {:error, :invalid_format} = TestSupport.UserId.parse("invalid")
+    end
+
+    test "returns error for wrong prefix" do
+      order_string = to_string(TestSupport.OrderId.new!(@test_uuid))
+      assert {:error, :invalid_format} = TestSupport.UserId.parse(order_string)
+    end
+
+    test "raises FunctionClauseError for non-binary input" do
+      assert_raise FunctionClauseError, fn ->
+        TestSupport.UserId.parse(123)
+      end
+    end
+
+    test "parses when type contains the separator character" do
+      typeid = TestSupport.TypeWithSeparatorId.new!("test-123")
+      {:ok, dumped} = TestSupport.TypeWithSeparatorId.dump(typeid)
+
+      {:ok, parsed} = TestSupport.TypeWithSeparatorId.parse(dumped)
+      assert parsed.id == "test-123"
+    end
+
+    test "parses with custom separator" do
+      typeid = TestSupport.CustomSeparatorId.new!(@test_uuid)
+      string = to_string(typeid)
+
+      {:ok, parsed} = TestSupport.CustomSeparatorId.parse(string)
+      assert parsed.id == typeid.id
+    end
+
+    test "returns error when parsing with wrong separator" do
+      wrong_string = "custom_test"
+      assert {:error, :invalid_format} = TestSupport.CustomSeparatorId.parse(wrong_string)
+    end
+
+    test "round-trips: new! -> to_string -> parse" do
+      typeid = TestSupport.UserId.new!(@test_uuid)
+      typeid_string = to_string(typeid)
+
+      {:ok, parsed} = TestSupport.UserId.parse(typeid_string)
+      assert parsed.id == typeid.id
+    end
+  end
+
+  describe "parse!/1" do
+    test "parses a valid string" do
+      typeid = TestSupport.UserId.new!(@test_uuid)
+      typeid_string = to_string(typeid)
+
+      parsed = TestSupport.UserId.parse!(typeid_string)
+      assert parsed.id == typeid.id
+    end
+
+    test "raises Error for invalid format" do
+      assert_raise Trogon.ObjectId.ValidationError, ~r/invalid_format/, fn ->
+        TestSupport.UserId.parse!("invalid")
+      end
+    end
+
+    test "raises Error for wrong prefix" do
+      order_string = to_string(TestSupport.OrderId.new!(@test_uuid))
+
+      assert_raise Trogon.ObjectId.ValidationError, ~r/invalid_format/, fn ->
+        TestSupport.UserId.parse!(order_string)
+      end
+    end
+
+    test "error includes the invalid value" do
+      invalid_value = "some_bad_value_123"
+
+      error =
+        assert_raise Trogon.ObjectId.ValidationError, fn ->
+          TestSupport.UserId.parse!(invalid_value)
+        end
+
+      assert error.value == invalid_value
+    end
+
+    test "parses with custom separator" do
+      typeid = TestSupport.CustomSeparatorId.new!(@test_uuid)
+      string = to_string(typeid)
+
+      parsed = TestSupport.CustomSeparatorId.parse!(string)
+      assert parsed.id == typeid.id
+    end
+  end
+
+  describe "type/0" do
+    test "returns :string" do
+      assert TestSupport.UserId.type() == :string
+    end
+  end
+
+  describe "cast/1" do
+    test "accepts the struct" do
+      typeid = TestSupport.UserId.new!(@test_uuid)
+      assert {:ok, ^typeid} = TestSupport.UserId.cast(typeid)
+    end
+
+    test "accepts binary strings" do
+      typeid = TestSupport.UserId.new!(@test_uuid)
+      typeid_string = to_string(typeid)
+
+      assert {:ok, parsed} = TestSupport.UserId.cast(typeid_string)
+      assert parsed.id == typeid.id
+    end
+
+    test "returns error for invalid string" do
+      assert :error = TestSupport.UserId.cast("invalid")
+    end
+
+    test "returns error for non-binary input" do
+      assert :error = TestSupport.UserId.cast(123)
+    end
+
+    test "returns error for struct with nil id" do
+      assert :error = TestSupport.UserId.cast(%TestSupport.UserId{id: nil})
+    end
+
+    test "returns {:ok, nil} for nil (nullable fields)" do
+      assert {:ok, nil} = TestSupport.UserId.cast(nil)
+    end
+
+    test "converts empty string to nil (form input pattern)" do
+      assert {:ok, nil} = TestSupport.UserId.cast("")
+    end
+
+    test "rejects prefix with empty suffix" do
+      assert :error = TestSupport.UserId.cast("user_")
+    end
+
+    test "rejects struct with empty id" do
+      assert :error = TestSupport.UserId.cast(%TestSupport.UserId{id: ""})
+    end
+
+    test "rejects struct with empty id (consistent with cast)" do
+      assert :error = TestSupport.UserId.cast(%TestSupport.UserId{id: ""})
+    end
+  end
+
+  describe "load/1" do
+    test "loads with storage_format: :full (default)" do
+      typeid = TestSupport.UserId.new!(@test_uuid)
+      typeid_string = to_string(typeid)
+
+      assert {:ok, loaded} = TestSupport.UserId.load(typeid_string)
+      assert loaded.id == typeid.id
+    end
+
+    test "loads with storage_format: :full" do
+      dumped = "full_#{@test_uuid}"
+      assert {:ok, loaded} = TestSupport.FullStorageId.load(dumped)
+      assert loaded.id == @test_uuid
+    end
+
+    test "loads with storage_format: :drop_prefix by reconstructing prefix" do
+      assert {:ok, loaded} = TestSupport.DropPrefixId.load(@test_uuid)
+      assert loaded.id == @test_uuid
+    end
+
+    test "returns error for invalid input" do
+      assert :error = TestSupport.UserId.load("invalid")
+    end
+
+    test "returns {:ok, nil} for nil (NULL from database)" do
+      assert {:ok, nil} = TestSupport.UserId.load(nil)
+    end
+
+    test "converts empty string to nil when loading" do
+      assert {:ok, nil} = TestSupport.UserId.load("")
+    end
+  end
+
+  describe "to_storage/1" do
+    test "converts valid struct to storage format (default :full)" do
+      typeid = TestSupport.UserId.new!(@test_uuid)
+
+      assert TestSupport.UserId.to_storage(typeid) == "user_#{@test_uuid}"
+    end
+
+    test "converts valid struct to storage format (:drop_prefix)" do
+      typeid = TestSupport.DropPrefixId.new!(@test_uuid)
+
+      assert TestSupport.DropPrefixId.to_storage(typeid) == @test_uuid
+    end
+
+    test "converts valid struct with custom separator" do
+      typeid = TestSupport.CustomSeparatorId.new!(@test_uuid)
+
+      assert TestSupport.CustomSeparatorId.to_storage(typeid) == "custom##{@test_uuid}"
+    end
+  end
+
+  describe "dump/1" do
+    test "dumps with storage_format: :full (default)" do
+      typeid = TestSupport.UserId.new!(@test_uuid)
+
+      assert {:ok, dumped} = TestSupport.UserId.dump(typeid)
+      assert dumped == "user_#{@test_uuid}"
+    end
+
+    test "dumps with storage_format: :full" do
+      typeid = TestSupport.FullStorageId.new!(@test_uuid)
+
+      assert {:ok, dumped} = TestSupport.FullStorageId.dump(typeid)
+      assert dumped == "full_#{@test_uuid}"
+    end
+
+    test "dumps with storage_format: :drop_prefix (only id)" do
+      typeid = TestSupport.DropPrefixId.new!(@test_uuid)
+
+      assert {:ok, dumped} = TestSupport.DropPrefixId.dump(typeid)
+      assert dumped == @test_uuid
+    end
+
+    test "dumps when type contains the separator character" do
+      typeid = TestSupport.TypeWithSeparatorId.new!("test-123")
+
+      {:ok, dumped} = TestSupport.TypeWithSeparatorId.dump(typeid)
+      assert dumped == "my_user_test-123"
+    end
+
+    test "returns error for invalid input" do
+      assert :error = TestSupport.UserId.dump("invalid")
+    end
+
+    test "returns error for struct with nil id" do
+      assert :error = TestSupport.UserId.dump(%TestSupport.UserId{id: nil})
+    end
+
+    test "returns error for struct with empty id" do
+      assert :error = TestSupport.UserId.dump(%TestSupport.UserId{id: ""})
+    end
+
+    test "returns {:ok, nil} for nil (store NULL in database)" do
+      assert {:ok, nil} = TestSupport.UserId.dump(nil)
+    end
+
+    test "delegates to to_storage for valid struct" do
+      typeid = TestSupport.UserId.new!(@test_uuid)
+
+      {:ok, dump_result} = TestSupport.UserId.dump(typeid)
+      storage_result = TestSupport.UserId.to_storage(typeid)
+
+      assert dump_result == storage_result
+    end
+
+    test "enforces struct pattern matching before calling to_storage" do
+      assert :error = TestSupport.UserId.dump(%{id: @test_uuid})
+      assert :error = TestSupport.UserId.dump(%{"id" => @test_uuid})
+      assert :error = TestSupport.UserId.dump(123)
+    end
+  end
+
+  describe "equal?/2" do
+    test "returns true for same id" do
+      uuid1 = TestSupport.UserId.new!(@test_uuid)
+      uuid1_dup = %TestSupport.UserId{id: uuid1.id}
+
+      assert TestSupport.UserId.equal?(uuid1, uuid1_dup)
+    end
+
+    test "returns false for different ids" do
+      uuid1 = TestSupport.UserId.new!(@test_uuid)
+      uuid2 = TestSupport.UserId.new!(@test_uuid_2)
+
+      assert not TestSupport.UserId.equal?(uuid1, uuid2)
+    end
+
+    test "returns false for invalid input" do
+      uuid1 = TestSupport.UserId.new!(@test_uuid)
+
+      assert not TestSupport.UserId.equal?(uuid1, "invalid")
+    end
+  end
+
+  describe "embed_as/1" do
+    test "returns :self" do
+      assert TestSupport.UserId.embed_as(:json) == :self
+    end
+  end
+
+  describe "String.Chars.to_string/1" do
+    test "converts to string with prefix" do
+      typeid = TestSupport.UserId.new!(@test_uuid)
+
+      assert to_string(typeid) == "user_#{@test_uuid}"
+    end
+
+    test "works in string interpolation" do
+      typeid = TestSupport.UserId.new!(@test_uuid)
+
+      assert "User ID: #{typeid}" == "User ID: user_#{@test_uuid}"
+    end
+
+    test "uses custom separator" do
+      typeid = TestSupport.CustomSeparatorId.new!(@test_uuid)
+
+      assert to_string(typeid) == "custom##{@test_uuid}"
+    end
+
+    test "different types produce different strings" do
+      user_id = TestSupport.UserId.new!(@test_uuid)
+      order_id = TestSupport.OrderId.new!(@test_uuid)
+
+      assert to_string(user_id) == "user_#{@test_uuid}"
+      assert to_string(order_id) == "order_#{@test_uuid}"
+    end
+  end
+
+  describe "Jason.Encoder.encode/2" do
+    test "protocol is implemented when Jason is available" do
+      assert {:ok, _} = Jason.encode(%TestSupport.UserId{id: "test"})
+      assert {:ok, _} = Jason.encode(%TestSupport.DropPrefixId{id: "test"})
+    end
+
+    test "encodes with json_format: :full (default)" do
+      typeid = TestSupport.UserId.new!(@test_uuid)
+
+      assert Jason.encode!(typeid) == ~s("user_#{@test_uuid}")
+    end
+
+    test "encodes with json_format: :drop_prefix" do
+      typeid = TestSupport.JsonDropPrefixId.new!(@test_uuid)
+
+      assert Jason.encode!(typeid) == ~s("#{@test_uuid}")
+    end
+
+    test "encodes with custom separator" do
+      typeid = TestSupport.CustomSeparatorId.new!(@test_uuid)
+
+      assert Jason.encode!(typeid) == ~s("custom##{@test_uuid}")
+    end
+
+    test "json_format is independent from storage_format" do
+      mixed_id = TestSupport.StorageDropJsonFullId.new!(@test_uuid)
+      assert {:ok, dumped} = TestSupport.StorageDropJsonFullId.dump(mixed_id)
+      assert dumped == @test_uuid
+      assert Jason.encode!(mixed_id) == ~s("mixed_#{@test_uuid}")
+
+      json_drop_id = TestSupport.JsonDropPrefixId.new!(@test_uuid)
+      assert {:ok, dumped} = TestSupport.JsonDropPrefixId.dump(json_drop_id)
+      assert dumped == "jsondrop_#{@test_uuid}"
+      assert Jason.encode!(json_drop_id) == ~s("#{@test_uuid}")
+    end
+
+    test "encodes within a map" do
+      typeid = TestSupport.UserId.new!(@test_uuid)
+      map = %{id: typeid, name: "test"}
+
+      assert Jason.encode!(map) == ~s({"id":"user_#{@test_uuid}","name":"test"})
+    end
+
+    test "encodes within a list" do
+      typeid1 = TestSupport.UserId.new!("id1")
+      typeid2 = TestSupport.UserId.new!("id2")
+
+      assert Jason.encode!([typeid1, typeid2]) == ~s(["user_id1","user_id2"])
+    end
+
+    test "raises FunctionClauseError for struct with nil id" do
+      assert_raise FunctionClauseError, fn ->
+        Jason.encode!(%TestSupport.UserId{id: nil})
+      end
+    end
+
+    test "encodes struct with empty string id (edge case from direct construction)" do
+      assert Jason.encode!(%TestSupport.UserId{id: ""}) == ~s("user_")
+    end
+  end
+
+  describe "format validation: :uuid" do
+    @valid_uuid "550e8400-e29b-41d4-a716-446655440000"
+
+    test "accepts valid UUID" do
+      result = TestSupport.UuidFormatId.parse("uuid_#{@valid_uuid}")
+
+      assert {:ok, %TestSupport.UuidFormatId{id: @valid_uuid}} = result
+    end
+
+    test "rejects invalid UUID" do
+      assert {:error, :invalid_uuid} = TestSupport.UuidFormatId.parse("uuid_not-a-uuid")
+    end
+
+    test "rejects empty UUID" do
+      assert {:error, :invalid_format} = TestSupport.UuidFormatId.parse("uuid_")
+    end
+
+    test "works with storage_format: :drop_prefix" do
+      result = TestSupport.UuidDropPrefixId.parse("uuiddrop_#{@valid_uuid}")
+
+      assert {:ok, %TestSupport.UuidDropPrefixId{id: @valid_uuid}} = result
+    end
+
+    test "validates the raw id value regardless of storage_format" do
+      assert {:error, :invalid_uuid} = TestSupport.UuidDropPrefixId.parse("uuiddrop_invalid")
+    end
+
+    test "parse! raises Error for invalid UUID" do
+      assert_raise Trogon.ObjectId.ValidationError, ~r/invalid_uuid/, fn ->
+        TestSupport.UuidFormatId.parse!("uuid_not-a-uuid")
+      end
+    end
+
+    test "cast delegates to parse and validates UUID" do
+      assert {:ok, %TestSupport.UuidFormatId{}} =
+               TestSupport.UuidFormatId.cast("uuid_#{@valid_uuid}")
+
+      assert :error = TestSupport.UuidFormatId.cast("uuid_invalid")
+    end
+  end
+
+  describe "format validation: :integer" do
+    test "accepts valid integer string" do
+      assert {:ok, %TestSupport.IntegerFormatId{id: "12345"}} =
+               TestSupport.IntegerFormatId.parse("int_12345")
+    end
+
+    test "accepts zero" do
+      assert {:ok, %TestSupport.IntegerFormatId{id: "0"}} =
+               TestSupport.IntegerFormatId.parse("int_0")
+    end
+
+    test "accepts negative integers" do
+      assert {:ok, %TestSupport.IntegerFormatId{id: "-123"}} =
+               TestSupport.IntegerFormatId.parse("int_-123")
+    end
+
+    test "rejects non-integer strings" do
+      assert {:error, :invalid_integer} = TestSupport.IntegerFormatId.parse("int_abc")
+    end
+
+    test "rejects integers with trailing characters" do
+      assert {:error, :invalid_integer} = TestSupport.IntegerFormatId.parse("int_123abc")
+    end
+
+    test "rejects floats" do
+      assert {:error, :invalid_integer} = TestSupport.IntegerFormatId.parse("int_12.34")
+    end
+
+    test "parse! raises Error for invalid integer" do
+      assert_raise Trogon.ObjectId.ValidationError, ~r/invalid_integer/, fn ->
+        TestSupport.IntegerFormatId.parse!("int_not-an-int")
+      end
+    end
+  end
+
+  describe "format validation: custom function" do
+    test "accepts values passing custom validation" do
+      assert {:ok, %TestSupport.CustomFormatId{id: "valid-123"}} =
+               TestSupport.CustomFormatId.parse("custom_fmt_valid-123")
+    end
+
+    test "rejects values failing custom validation" do
+      assert {:error, :invalid_custom_format} =
+               TestSupport.CustomFormatId.parse("custom_fmt_invalid-value")
+    end
+
+    test "parse! raises Error for invalid custom format" do
+      assert_raise Trogon.ObjectId.ValidationError, ~r/invalid_custom_format/, fn ->
+        TestSupport.CustomFormatId.parse!("custom_fmt_bad")
+      end
+    end
+  end
+
+  describe "format validation: no format specified" do
+    test "ObjectId without format accepts any value" do
+      assert {:ok, %TestSupport.UserId{id: "any-value-here"}} =
+               TestSupport.UserId.parse("user_any-value-here")
+    end
+  end
+
+  describe "format validation: compile-time errors" do
+    test "raises ArgumentError when function does not exist" do
+      assert_raise ArgumentError, ~r/String.nonexistent\/1 is not defined/, fn ->
+        Code.compile_string("""
+        defmodule TestNonexistentFunc do
+          use Trogon.ObjectId, object_type: "test", validate: {String, :nonexistent}
+        end
+        """)
+      end
+    end
+
+    test "raises NimbleOptions.ValidationError for invalid validate type" do
+      assert_raise NimbleOptions.ValidationError, fn ->
+        Code.compile_string("""
+        defmodule TestInvalidValidate do
+          use Trogon.ObjectId, object_type: "test", validate: :invalid
+        end
+        """)
+      end
+    end
+  end
+
+  describe "proto: option" do
+    test "derives object_type from proto enum value" do
+      assert TestSupport.ProtoTicketId.object_type() == "ticket"
+    end
+
+    test "uses default separator when proto does not specify one" do
+      assert TestSupport.ProtoTicketId.prefix() == "ticket_"
+    end
+
+    test "derives custom separator from proto enum value" do
+      assert TestSupport.ProtoWorkspaceId.object_type() == "workspace"
+      assert TestSupport.ProtoWorkspaceId.prefix() == "workspace#"
+    end
+
+    test "forwards additional options like storage_format" do
+      typeid = TestSupport.ProtoWorkspaceId.new!("abc-123")
+      assert {:ok, dumped} = TestSupport.ProtoWorkspaceId.dump(typeid)
+      assert dumped == "abc-123"
+    end
+
+    test "round-trips: new! -> to_string -> parse" do
+      typeid = TestSupport.ProtoTicketId.new!("abc-123")
+      assert to_string(typeid) == "ticket_abc-123"
+      assert {:ok, parsed} = TestSupport.ProtoTicketId.parse("ticket_abc-123")
+      assert parsed.id == "abc-123"
+    end
+  end
+
+  describe "is_object_id/1" do
+    test "returns true for an ObjectId struct" do
+      user_id = TestSupport.UserId.new!("abc-123")
+      assert is_object_id(user_id)
+    end
+
+    test "returns false for a plain map" do
+      refute is_object_id(%{id: "abc-123"})
+    end
+
+    test "returns false for a non-ObjectId struct" do
+      refute is_object_id(%URI{path: "/"})
+    end
+
+    test "returns false for non-map values" do
+      refute is_object_id("user_abc-123")
+      refute is_object_id(123)
+      refute is_object_id(nil)
+    end
+
+    test "works in guard clauses" do
+      user_id = TestSupport.UserId.new!("abc-123")
+
+      result =
+        case user_id do
+          x when is_object_id(x) -> :object_id
+          _ -> :other
+        end
+
+      assert result == :object_id
+    end
+
+    test "rejects non-ObjectId in guard clauses" do
+      result =
+        case %{id: "abc-123"} do
+          x when is_object_id(x) -> :object_id
+          _ -> :other
+        end
+
+      assert result == :other
+    end
+  end
+end

--- a/apps/trogon_object_id/test/trogon/union_object_id_test.exs
+++ b/apps/trogon_object_id/test/trogon/union_object_id_test.exs
@@ -1,0 +1,475 @@
+defmodule Trogon.UnionObjectIdTest do
+  use ExUnit.Case
+
+  alias Trogon.ObjectId.TestSupport
+
+  @tenant_id_value "abc-123"
+  @system_id_value "xyz-789"
+  @service_id_value "srv-456"
+
+  describe "new/1" do
+    test "wraps a TenantId" do
+      tenant_id = TestSupport.TenantId.new!(@tenant_id_value)
+      union = TestSupport.PrincipalId.new(tenant_id)
+
+      assert union == %TestSupport.PrincipalId{id: tenant_id}
+    end
+
+    test "wraps a SystemId" do
+      system_id = TestSupport.SystemId.new!(@system_id_value)
+      union = TestSupport.ContextId.new(system_id)
+
+      assert union == %TestSupport.ContextId{id: system_id}
+    end
+
+    test "supports unions with more than two types" do
+      tenant_id = TestSupport.TenantId.new!(@tenant_id_value)
+      system_id = TestSupport.SystemId.new!(@system_id_value)
+      service_id = TestSupport.ServiceId.new!(@service_id_value)
+
+      assert TestSupport.PrincipalId.new(tenant_id) == %TestSupport.PrincipalId{id: tenant_id}
+      assert TestSupport.PrincipalId.new(system_id) == %TestSupport.PrincipalId{id: system_id}
+      assert TestSupport.PrincipalId.new(service_id) == %TestSupport.PrincipalId{id: service_id}
+    end
+
+    test "distinguishes between different unions" do
+      tenant_id = TestSupport.TenantId.new!(@tenant_id_value)
+      mod_union = TestSupport.ContextId.new(tenant_id)
+      actor_union = TestSupport.PrincipalId.new(tenant_id)
+
+      assert mod_union == %TestSupport.ContextId{id: tenant_id}
+      assert actor_union == %TestSupport.PrincipalId{id: tenant_id}
+    end
+  end
+
+  describe "parse/1" do
+    test "parses a TenantId string" do
+      tenant_string = to_string(TestSupport.TenantId.new!(@tenant_id_value))
+
+      assert {:ok, %TestSupport.ContextId{id: %TestSupport.TenantId{id: @tenant_id_value}}} =
+               TestSupport.ContextId.parse(tenant_string)
+    end
+
+    test "parses a SystemId string" do
+      system_string = to_string(TestSupport.SystemId.new!(@system_id_value))
+
+      assert {:ok, %TestSupport.ContextId{id: %TestSupport.SystemId{id: @system_id_value}}} =
+               TestSupport.ContextId.parse(system_string)
+    end
+
+    test "tries each type in order and returns first match" do
+      tenant_string = to_string(TestSupport.TenantId.new!(@tenant_id_value))
+
+      assert {:ok, %TestSupport.ContextId{id: %TestSupport.TenantId{}}} = TestSupport.ContextId.parse(tenant_string)
+    end
+
+    test "returns error for empty string" do
+      assert {:error, :invalid_format} = TestSupport.ContextId.parse("")
+    end
+
+    test "returns error for invalid string" do
+      assert {:error, :invalid_format} = TestSupport.ContextId.parse("invalid")
+    end
+
+    test "returns error when string doesn't match any type" do
+      assert {:error, :invalid_format} = TestSupport.ContextId.parse("unknown_abc-123")
+    end
+
+    test "handles three-type unions" do
+      tenant_string = to_string(TestSupport.TenantId.new!(@tenant_id_value))
+      system_string = to_string(TestSupport.SystemId.new!(@system_id_value))
+      service_string = to_string(TestSupport.ServiceId.new!(@service_id_value))
+
+      assert {:ok, %TestSupport.PrincipalId{id: %TestSupport.TenantId{id: @tenant_id_value}}} =
+               TestSupport.PrincipalId.parse(tenant_string)
+
+      assert {:ok, %TestSupport.PrincipalId{id: %TestSupport.SystemId{id: @system_id_value}}} =
+               TestSupport.PrincipalId.parse(system_string)
+
+      assert {:ok, %TestSupport.PrincipalId{id: %TestSupport.ServiceId{id: @service_id_value}}} =
+               TestSupport.PrincipalId.parse(service_string)
+    end
+  end
+
+  describe "parse!/1" do
+    test "parses a TenantId string" do
+      tenant_string = to_string(TestSupport.TenantId.new!(@tenant_id_value))
+
+      result = TestSupport.ContextId.parse!(tenant_string)
+
+      assert result == %TestSupport.ContextId{id: %TestSupport.TenantId{id: @tenant_id_value}}
+    end
+
+    test "parses a SystemId string" do
+      system_string = to_string(TestSupport.SystemId.new!(@system_id_value))
+
+      result = TestSupport.ContextId.parse!(system_string)
+
+      assert result == %TestSupport.ContextId{id: %TestSupport.SystemId{id: @system_id_value}}
+    end
+
+    test "raises ValidationError for invalid string" do
+      assert_raise Trogon.ObjectId.ValidationError, ~r/invalid_format/, fn ->
+        TestSupport.ContextId.parse!("invalid")
+      end
+    end
+
+    test "raises ValidationError for empty string" do
+      assert_raise Trogon.ObjectId.ValidationError, ~r/invalid_format/, fn ->
+        TestSupport.ContextId.parse!("")
+      end
+    end
+
+    test "raises ValidationError when string doesn't match any type" do
+      assert_raise Trogon.ObjectId.ValidationError, ~r/invalid_format/, fn ->
+        TestSupport.ContextId.parse!("unknown_abc-123")
+      end
+    end
+
+    test "error includes the invalid value" do
+      invalid_value = "some_bad_value_123"
+
+      error =
+        assert_raise Trogon.ObjectId.ValidationError, fn ->
+          TestSupport.ContextId.parse!(invalid_value)
+        end
+
+      assert error.value == invalid_value
+    end
+
+    test "handles three-type unions" do
+      tenant_string = to_string(TestSupport.TenantId.new!(@tenant_id_value))
+      system_string = to_string(TestSupport.SystemId.new!(@system_id_value))
+      service_string = to_string(TestSupport.ServiceId.new!(@service_id_value))
+
+      assert TestSupport.PrincipalId.parse!(tenant_string) ==
+               %TestSupport.PrincipalId{id: %TestSupport.TenantId{id: @tenant_id_value}}
+
+      assert TestSupport.PrincipalId.parse!(system_string) ==
+               %TestSupport.PrincipalId{id: %TestSupport.SystemId{id: @system_id_value}}
+
+      assert TestSupport.PrincipalId.parse!(service_string) ==
+               %TestSupport.PrincipalId{id: %TestSupport.ServiceId{id: @service_id_value}}
+    end
+  end
+
+  describe "to_storage/1" do
+    test "converts TenantId to storage string with prefix" do
+      tenant_id = TestSupport.TenantId.new!(@tenant_id_value)
+      union = TestSupport.ContextId.new(tenant_id)
+
+      assert TestSupport.ContextId.to_storage(union) == "tenant_#{@tenant_id_value}"
+    end
+
+    test "converts SystemId to storage string with prefix" do
+      system_id = TestSupport.SystemId.new!(@system_id_value)
+      union = TestSupport.ContextId.new(system_id)
+
+      assert TestSupport.ContextId.to_storage(union) == "system_#{@system_id_value}"
+    end
+
+    test "storage string is the same as to_string output" do
+      tenant_id = TestSupport.TenantId.new!(@tenant_id_value)
+      union = TestSupport.ContextId.new(tenant_id)
+
+      assert TestSupport.ContextId.to_storage(union) == to_string(union)
+    end
+
+    test "raises FunctionClauseError when id is nil" do
+      assert_raise FunctionClauseError, fn ->
+        TestSupport.ContextId.to_storage(%TestSupport.ContextId{id: nil})
+      end
+    end
+
+    test "raises FunctionClauseError when id is not a struct" do
+      assert_raise FunctionClauseError, fn ->
+        TestSupport.ContextId.to_storage(%TestSupport.ContextId{id: "string"})
+      end
+    end
+  end
+
+  describe "String.Chars protocol" do
+    test "converts TenantId to string with prefix" do
+      tenant_id = TestSupport.TenantId.new!(@tenant_id_value)
+      union = TestSupport.ContextId.new(tenant_id)
+
+      assert to_string(union) == "tenant_#{@tenant_id_value}"
+    end
+
+    test "converts SystemId to string with prefix" do
+      system_id = TestSupport.SystemId.new!(@system_id_value)
+      union = TestSupport.ContextId.new(system_id)
+
+      assert to_string(union) == "system_#{@system_id_value}"
+    end
+
+    test "can be used in string interpolation" do
+      tenant_id = TestSupport.TenantId.new!(@tenant_id_value)
+      union = TestSupport.ContextId.new(tenant_id)
+
+      result = "Context: #{union}"
+
+      assert result == "Context: tenant_#{@tenant_id_value}"
+    end
+  end
+
+  describe "cast/1" do
+    test "casts nil" do
+      assert {:ok, nil} = TestSupport.ContextId.cast(nil)
+    end
+
+    test "casts empty string to nil" do
+      assert {:ok, nil} = TestSupport.ContextId.cast("")
+    end
+
+    test "casts a union struct" do
+      assert {:ok, %TestSupport.ContextId{id: %TestSupport.TenantId{id: @tenant_id_value}}} =
+               TestSupport.ContextId.cast(%TestSupport.ContextId{id: TestSupport.TenantId.new!(@tenant_id_value)})
+    end
+
+    test "casts a valid string to TenantId" do
+      tenant_string = to_string(TestSupport.TenantId.new!(@tenant_id_value))
+
+      assert {:ok, %TestSupport.ContextId{id: %TestSupport.TenantId{id: @tenant_id_value}}} =
+               TestSupport.ContextId.cast(tenant_string)
+    end
+
+    test "casts a valid string to SystemId" do
+      system_string = to_string(TestSupport.SystemId.new!(@system_id_value))
+
+      assert {:ok, %TestSupport.ContextId{id: %TestSupport.SystemId{id: @system_id_value}}} =
+               TestSupport.ContextId.cast(system_string)
+    end
+
+    test "returns error for invalid string" do
+      assert :error = TestSupport.ContextId.cast("invalid")
+    end
+
+    test "returns error for non-string non-struct input" do
+      assert :error = TestSupport.ContextId.cast(123)
+      assert :error = TestSupport.ContextId.cast([])
+      assert :error = TestSupport.ContextId.cast(%{})
+    end
+  end
+
+  describe "load/1" do
+    test "loads nil" do
+      assert {:ok, nil} = TestSupport.ContextId.load(nil)
+    end
+
+    test "loads empty string as nil" do
+      assert {:ok, nil} = TestSupport.ContextId.load("")
+    end
+
+    test "loads a valid TenantId string" do
+      tenant_string = to_string(TestSupport.TenantId.new!(@tenant_id_value))
+
+      assert {:ok, %TestSupport.ContextId{id: %TestSupport.TenantId{id: @tenant_id_value}}} =
+               TestSupport.ContextId.load(tenant_string)
+    end
+
+    test "loads a valid SystemId string" do
+      system_string = to_string(TestSupport.SystemId.new!(@system_id_value))
+
+      assert {:ok, %TestSupport.ContextId{id: %TestSupport.SystemId{id: @system_id_value}}} =
+               TestSupport.ContextId.load(system_string)
+    end
+
+    test "returns error for invalid string" do
+      assert :error = TestSupport.ContextId.load("invalid")
+    end
+
+    test "returns error for non-string input" do
+      assert :error = TestSupport.ContextId.load(123)
+      assert :error = TestSupport.ContextId.load([])
+    end
+  end
+
+  describe "dump/1" do
+    test "dumps nil" do
+      assert {:ok, nil} = TestSupport.ContextId.dump(nil)
+    end
+
+    test "dumps a union with TenantId" do
+      tenant_id = TestSupport.TenantId.new!(@tenant_id_value)
+      union = TestSupport.ContextId.new(tenant_id)
+
+      assert {:ok, "tenant_#{@tenant_id_value}"} = TestSupport.ContextId.dump(union)
+    end
+
+    test "dumps a union with SystemId" do
+      system_id = TestSupport.SystemId.new!(@system_id_value)
+      union = TestSupport.ContextId.new(system_id)
+
+      assert {:ok, "system_#{@system_id_value}"} = TestSupport.ContextId.dump(union)
+    end
+
+    test "returns error for non-union struct" do
+      assert :error = TestSupport.ContextId.dump(123)
+      assert :error = TestSupport.ContextId.dump("string")
+      assert :error = TestSupport.ContextId.dump(%{})
+    end
+
+    test "returns error when id is nil" do
+      assert :error = TestSupport.ContextId.dump(%TestSupport.ContextId{id: nil})
+    end
+
+    test "returns error when id is not a struct" do
+      assert :error = TestSupport.ContextId.dump(%TestSupport.ContextId{id: "string"})
+    end
+  end
+
+  describe "type/0" do
+    test "returns :string" do
+      assert TestSupport.ContextId.type() == :string
+    end
+  end
+
+  describe "equal?/2" do
+    test "returns true for equal unions with TenantId" do
+      tenant_id = TestSupport.TenantId.new!(@tenant_id_value)
+      union1 = TestSupport.ContextId.new(tenant_id)
+      union2 = TestSupport.ContextId.new(tenant_id)
+
+      assert TestSupport.ContextId.equal?(union1, union2)
+    end
+
+    test "returns false for unions with different inner values" do
+      tenant_id1 = TestSupport.TenantId.new!(@tenant_id_value)
+      tenant_id2 = TestSupport.TenantId.new!("different")
+      union1 = TestSupport.ContextId.new(tenant_id1)
+      union2 = TestSupport.ContextId.new(tenant_id2)
+
+      assert not TestSupport.ContextId.equal?(union1, union2)
+    end
+
+    test "returns false for unions with different inner types" do
+      tenant_id = TestSupport.TenantId.new!(@tenant_id_value)
+      system_id = TestSupport.SystemId.new!(@tenant_id_value)
+      tenant_union = TestSupport.ContextId.new(tenant_id)
+      system_union = TestSupport.ContextId.new(system_id)
+
+      assert not TestSupport.ContextId.equal?(tenant_union, system_union)
+    end
+
+    test "returns false when comparing with non-union" do
+      tenant_id = TestSupport.TenantId.new!(@tenant_id_value)
+      union = TestSupport.ContextId.new(tenant_id)
+
+      assert not TestSupport.ContextId.equal?(union, nil)
+      assert not TestSupport.ContextId.equal?(union, "string")
+    end
+  end
+
+  describe "embed_as/1" do
+    test "returns :self" do
+      assert TestSupport.ContextId.embed_as(:atom) == :self
+      assert TestSupport.ContextId.embed_as(:json) == :self
+    end
+  end
+
+  describe "Jason.Encoder protocol" do
+    test "encodes TenantId union to JSON" do
+      tenant_id = TestSupport.TenantId.new!(@tenant_id_value)
+      union = TestSupport.ContextId.new(tenant_id)
+
+      json = Jason.encode!(union)
+
+      assert json == Jason.encode!("tenant_#{@tenant_id_value}")
+    end
+
+    test "encodes SystemId union to JSON" do
+      system_id = TestSupport.SystemId.new!(@system_id_value)
+      union = TestSupport.ContextId.new(system_id)
+
+      json = Jason.encode!(union)
+
+      assert json == Jason.encode!("system_#{@system_id_value}")
+    end
+
+    test "decodes JSON to union via cast" do
+      tenant_id = TestSupport.TenantId.new!(@tenant_id_value)
+      union = TestSupport.ContextId.new(tenant_id)
+
+      json = Jason.encode!(union)
+      decoded = Jason.decode!(json)
+
+      assert {:ok, %TestSupport.ContextId{id: %TestSupport.TenantId{id: @tenant_id_value}}} =
+               TestSupport.ContextId.cast(decoded)
+    end
+  end
+
+  describe "parse/1 with validated inner types" do
+    test "rejects invalid value for a validated inner type" do
+      assert {:error, _} = TestSupport.ValidatedUnionId.parse("uuid_not-a-uuid")
+    end
+
+    test "accepts valid value for a validated inner type" do
+      uuid = Uniq.UUID.uuid4()
+
+      assert {:ok, %TestSupport.ValidatedUnionId{id: %TestSupport.UuidFormatId{id: ^uuid}}} =
+               TestSupport.ValidatedUnionId.parse("uuid_#{uuid}")
+    end
+
+    test "non-validated inner type still parses normally" do
+      assert {:ok, %TestSupport.ValidatedUnionId{id: %TestSupport.TenantId{id: "abc-123"}}} =
+               TestSupport.ValidatedUnionId.parse("tenant_abc-123")
+    end
+  end
+
+  describe "Prefix collision detection at compile time" do
+    test "raises CompileError for overlapping prefixes" do
+      assert_raise CompileError, ~r/UnionObjectId prefix collision/, fn ->
+        Code.compile_string("""
+        defmodule Trogon.ObjectId.TestSupport.BadUnionId do
+          use Trogon.UnionObjectId, types: [Trogon.ObjectId.TestSupport.TenantId, Trogon.ObjectId.TestSupport.TenantId]
+        end
+        """)
+      end
+    end
+
+    test "raises CompileError for empty types list" do
+      assert_raise CompileError, ~r/types list cannot be empty/, fn ->
+        Code.compile_string("""
+        defmodule Trogon.ObjectId.TestSupport.EmptyUnionId do
+          use Trogon.UnionObjectId, types: []
+        end
+        """)
+      end
+    end
+
+    test "raises CompileError for ambiguous prefixes with different separators" do
+      assert_raise CompileError, ~r/UnionObjectId prefix collision/, fn ->
+        Code.compile_string("""
+        defmodule Trogon.ObjectId.TestSupport.AmbiguousUnionId do
+          use Trogon.UnionObjectId,
+            types: [Trogon.ObjectId.TestSupport.AmbiguousPrefixIdA, Trogon.ObjectId.TestSupport.AmbiguousPrefixIdB]
+        end
+        """)
+      end
+    end
+  end
+
+  describe "Union with multiple types" do
+    test "correctly identifies TenantId variant" do
+      tenant_string = to_string(TestSupport.TenantId.new!(@tenant_id_value))
+
+      assert {:ok, %TestSupport.PrincipalId{id: %TestSupport.TenantId{id: @tenant_id_value}}} =
+               TestSupport.PrincipalId.parse(tenant_string)
+    end
+
+    test "correctly identifies SystemId variant" do
+      system_string = to_string(TestSupport.SystemId.new!(@system_id_value))
+
+      assert {:ok, %TestSupport.PrincipalId{id: %TestSupport.SystemId{id: @system_id_value}}} =
+               TestSupport.PrincipalId.parse(system_string)
+    end
+
+    test "correctly identifies ServiceId variant" do
+      service_string = to_string(TestSupport.ServiceId.new!(@service_id_value))
+
+      assert {:ok, %TestSupport.PrincipalId{id: %TestSupport.ServiceId{id: @service_id_value}}} =
+               TestSupport.PrincipalId.parse(service_string)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- ObjectId is a general-purpose concept not coupled to Commanded, extracting it allows adoption without pulling in the full trogon_commanded dependency tree (commanded, polymorphic_embed, etc.)
- trogon_commanded now depends on trogon_object_id as an umbrella sibling