### PR TITLE
fix(ci): pin all actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,14 +11,14 @@ jobs:
     name: Publish to Hex.pm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: 1password/load-secrets-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: 1password/load-secrets-action@2bfca7363ef8f96bb66d38dd50981bf948040c7e # v4
         with:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           HEX_API_KEY: "${{ secrets.SECRETS_VAULT }}/HEX_API_KEY"
-      - uses: straw-hat-team/github-actions-workflows/elixir/umbrella-publish@master
+      - uses: straw-hat-team/github-actions-workflows/elixir/umbrella-publish@9d9de721069136b981894947c85a0c27ab14a392 # master
         with:
           hex-api-key: ${{ env.HEX_API_KEY }}
           ref-name: ${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   qa:
-    uses: straw-hat-team/github-actions-workflows/.github/workflows/elixir-quality-assurance.yml@master
+    uses: straw-hat-team/github-actions-workflows/.github/workflows/elixir-quality-assurance.yml@9d9de721069136b981894947c85a0c27ab14a392 # master

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,14 +19,14 @@ jobs:
     name: Publish Docs to Hex.pm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: 1password/load-secrets-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: 1password/load-secrets-action@2bfca7363ef8f96bb66d38dd50981bf948040c7e # v4
         with:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           HEX_API_KEY: "${{ secrets.SECRETS_VAULT }}/HEX_API_KEY"
-      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@master
+      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@9d9de721069136b981894947c85a0c27ab14a392 # master
         with:
           hex-api-key: ${{ env.HEX_API_KEY }}
           package-name: ${{ inputs.package-name }}


### PR DESCRIPTION
- Repository action policy requires all actions to be pinned to full-length commit SHAs, which was blocking CI on other branches