### PR TITLE
fix(ci): update github-actions-workflows SHA to include pinned actions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           HEX_API_KEY: "${{ secrets.SECRETS_VAULT }}/HEX_API_KEY"
-      - uses: straw-hat-team/github-actions-workflows/elixir/umbrella-publish@380a7d55273bbfff3291d0febae9caece989dce6 # master
+      - uses: straw-hat-team/github-actions-workflows/elixir/umbrella-publish@a47798ffe54ef6079d7a1212ea93058cb8d0d4d9 # master
         with:
           hex-api-key: ${{ env.HEX_API_KEY }}
           ref-name: ${{ github.ref_name }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           HEX_API_KEY: "${{ secrets.SECRETS_VAULT }}/HEX_API_KEY"
-      - uses: straw-hat-team/github-actions-workflows/elixir/umbrella-publish@9d9de721069136b981894947c85a0c27ab14a392 # master
+      - uses: straw-hat-team/github-actions-workflows/elixir/umbrella-publish@380a7d55273bbfff3291d0febae9caece989dce6 # master
         with:
           hex-api-key: ${{ env.HEX_API_KEY }}
           ref-name: ${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   qa:
-    uses: straw-hat-team/github-actions-workflows/.github/workflows/elixir-quality-assurance.yml@380a7d55273bbfff3291d0febae9caece989dce6 # master
+    uses: straw-hat-team/github-actions-workflows/.github/workflows/elixir-quality-assurance.yml@a47798ffe54ef6079d7a1212ea93058cb8d0d4d9 # master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   qa:
-    uses: straw-hat-team/github-actions-workflows/.github/workflows/elixir-quality-assurance.yml@9d9de721069136b981894947c85a0c27ab14a392 # master
+    uses: straw-hat-team/github-actions-workflows/.github/workflows/elixir-quality-assurance.yml@380a7d55273bbfff3291d0febae9caece989dce6 # master

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           HEX_API_KEY: "${{ secrets.SECRETS_VAULT }}/HEX_API_KEY"
-      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@380a7d55273bbfff3291d0febae9caece989dce6 # master
+      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@a47798ffe54ef6079d7a1212ea93058cb8d0d4d9 # master
         with:
           hex-api-key: ${{ env.HEX_API_KEY }}
           package-name: ${{ inputs.package-name }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           HEX_API_KEY: "${{ secrets.SECRETS_VAULT }}/HEX_API_KEY"
-      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@9d9de721069136b981894947c85a0c27ab14a392 # master
+      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@380a7d55273bbfff3291d0febae9caece989dce6 # master
         with:
           hex-api-key: ${{ env.HEX_API_KEY }}
           package-name: ${{ inputs.package-name }}


### PR DESCRIPTION
- The previous SHA pointed to a version of github-actions-workflows where internal actions were not pinned to commit SHAs, causing CI failures