### PR TITLE
fix(trogon_proto): enable docs on generated protobuf modules

### DIFF
--- a/apps/trogon_proto/buf.gen.yaml
+++ b/apps/trogon_proto/buf.gen.yaml
@@ -9,3 +9,4 @@ plugins:
     out: lib/__generated__
     opt:
       - gen_descriptors=true
+      - include_docs=true

--- a/apps/trogon_proto/lib/__generated__/trogon/consistency/v1alpha1/consistency.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/consistency/v1alpha1/consistency.pb.ex
@@ -160,27 +160,31 @@ defmodule TrogonProto.Consistency.V1Alpha1.Consistency do
     }
   end
 
-  oneof :requirement, 0
+  oneof(:requirement, 0)
 
-  field :min_version, 1,
+  field(:min_version, 1,
     type: TrogonProto.Consistency.V1Alpha1.MinVersion,
     json_name: "minVersion",
     oneof: 0
+  )
 
-  field :exact_version, 2,
+  field(:exact_version, 2,
     type: TrogonProto.Consistency.V1Alpha1.ExactVersion,
     json_name: "exactVersion",
     oneof: 0
+  )
 
-  field :timeout_duration, 3,
+  field(:timeout_duration, 3,
     proto3_optional: true,
     type: Google.Protobuf.Duration,
     json_name: "timeoutDuration"
+  )
 
-  field :delay_duration, 4,
+  field(:delay_duration, 4,
     proto3_optional: true,
     type: Google.Protobuf.Duration,
     json_name: "delayDuration"
+  )
 end
 
 defmodule TrogonProto.Consistency.V1Alpha1.MinVersion do
@@ -225,7 +229,7 @@ defmodule TrogonProto.Consistency.V1Alpha1.MinVersion do
     }
   end
 
-  field :version, 1, type: :int64
+  field(:version, 1, type: :int64)
 end
 
 defmodule TrogonProto.Consistency.V1Alpha1.ExactVersion do
@@ -270,5 +274,5 @@ defmodule TrogonProto.Consistency.V1Alpha1.ExactVersion do
     }
   end
 
-  field :version, 1, type: :int64
+  field(:version, 1, type: :int64)
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/consistency/v1alpha1/consistency.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/consistency/v1alpha1/consistency.pb.ex
@@ -1,5 +1,69 @@
 defmodule TrogonProto.Consistency.V1Alpha1.Consistency do
-  @moduledoc false
+  @moduledoc """
+  Configuration for read-your-writes consistency guarantees in eventual consistency systems.
+
+  Used in query operations to wait for projections/read models to catch up to a specific version
+  after a write operation. This enables clients to immediately read their own writes despite
+  projection lag in CQRS/Event Sourcing architectures.
+
+  ## Consistency Modes
+
+  ### MinVersion (Recommended - Read-Your-Writes)
+  Waits for projection to reach AT LEAST the specified version. Will use newer data if available.
+  Use this after mutations to ensure you can immediately read what you just wrote.
+
+  ### ExactVersion (Strict - Reproducible Snapshots)
+  Waits for projection to reach EXACTLY the specified version. Rejects if version is newer.
+  Use this only when you need reproducible queries at a specific point-in-time (audits, reports).
+
+  ## Usage Pattern
+
+  1. Client performs mutation (e.g., CreateOrder, UpdateInventory)
+  2. Server returns stream_version (e.g., version 5)
+  3. Client immediately queries with Consistency:
+     - min_version { version: 5 }  (recommended - read-your-writes)
+     - exact_version { version: 5 }  (strict - reproducible snapshot)
+  4. Server retries query until projection reaches version or timeout
+
+  ## Example
+
+  ```protobuf
+  // Mutation response
+  message CreateOrderResponse {
+    string order_id = 1;
+    uint64 stream_version = 2;  // Returns: 5
+  }
+
+  // Read-your-writes (recommended)
+  message GetOrderRequest {
+    string order_id = 1;
+    trogon.consistency.v1alpha1.Consistency consistency = 2;
+  }
+
+  GetOrderRequest {
+    order_id: "order-123",
+    consistency: {
+      min_version: { version: 5 },
+      timeout_duration: "1s",
+      delay_duration: "100ms"
+    }
+  }
+  ```
+
+  ## Server Implementation Guidelines
+
+  Servers should:
+  - Enforce reasonable timeout limits (e.g., default 1s, max 5s)
+  - Enforce reasonable delay limits (e.g., default 100ms, max 500ms)
+  - Return unavailable status on timeout with appropriate error metadata
+  - Return failed precondition status on snapshot expired (ExactVersion only)
+  - Log when clamping client-provided values
+
+  ## Reference
+
+  Inspired by SpiceDB's Consistency patterns (at_least_as_fresh and at_exact_snapshot modes).
+  See: https://authzed.com/docs/spicedb/concepts/consistency
+  """
 
   use Protobuf,
     full_name: "trogon.consistency.v1alpha1.Consistency",
@@ -96,35 +160,33 @@ defmodule TrogonProto.Consistency.V1Alpha1.Consistency do
     }
   end
 
-  oneof(:requirement, 0)
+  oneof :requirement, 0
 
-  field(:min_version, 1,
+  field :min_version, 1,
     type: TrogonProto.Consistency.V1Alpha1.MinVersion,
     json_name: "minVersion",
     oneof: 0
-  )
 
-  field(:exact_version, 2,
+  field :exact_version, 2,
     type: TrogonProto.Consistency.V1Alpha1.ExactVersion,
     json_name: "exactVersion",
     oneof: 0
-  )
 
-  field(:timeout_duration, 3,
+  field :timeout_duration, 3,
     proto3_optional: true,
     type: Google.Protobuf.Duration,
     json_name: "timeoutDuration"
-  )
 
-  field(:delay_duration, 4,
+  field :delay_duration, 4,
     proto3_optional: true,
     type: Google.Protobuf.Duration,
     json_name: "delayDuration"
-  )
 end
 
 defmodule TrogonProto.Consistency.V1Alpha1.MinVersion do
-  @moduledoc false
+  @moduledoc """
+  Wait for projection to be at least as fresh as the specified version.
+  """
 
   use Protobuf,
     full_name: "trogon.consistency.v1alpha1.MinVersion",
@@ -163,11 +225,13 @@ defmodule TrogonProto.Consistency.V1Alpha1.MinVersion do
     }
   end
 
-  field(:version, 1, type: :int64)
+  field :version, 1, type: :int64
 end
 
 defmodule TrogonProto.Consistency.V1Alpha1.ExactVersion do
-  @moduledoc false
+  @moduledoc """
+  Wait for projection to reach exactly the specified version (strict snapshot).
+  """
 
   use Protobuf,
     full_name: "trogon.consistency.v1alpha1.ExactVersion",
@@ -206,5 +270,5 @@ defmodule TrogonProto.Consistency.V1Alpha1.ExactVersion do
     }
   end
 
-  field(:version, 1, type: :int64)
+  field :version, 1, type: :int64
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/env/v1alpha1/options.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/env/v1alpha1/options.pb.ex
@@ -60,14 +60,15 @@ defmodule TrogonProto.Env.V1Alpha1.Trim do
     }
   end
 
-  oneof :by, 0
+  oneof(:by, 0)
 
-  field :unicode_whitespace, 1,
+  field(:unicode_whitespace, 1,
     type: Google.Protobuf.Empty,
     json_name: "unicodeWhitespace",
     oneof: 0
+  )
 
-  field :chars, 2, type: :string, oneof: 0
+  field(:chars, 2, type: :string, oneof: 0)
 end
 
 defmodule TrogonProto.Env.V1Alpha1.EnvVarOption.TagsEntry do
@@ -133,8 +134,8 @@ defmodule TrogonProto.Env.V1Alpha1.EnvVarOption.TagsEntry do
     }
   end
 
-  field :key, 1, type: :string
-  field :value, 2, type: :string
+  field(:key, 1, type: :string)
+  field(:value, 2, type: :string)
 end
 
 defmodule TrogonProto.Env.V1Alpha1.EnvVarOption do
@@ -300,11 +301,11 @@ defmodule TrogonProto.Env.V1Alpha1.EnvVarOption do
     }
   end
 
-  field :visibility, 1, type: TrogonProto.Env.V1Alpha1.Visibility, enum: true
-  field :default_value, 2, proto3_optional: true, type: :string, json_name: "defaultValue"
-  field :split_delimiter, 4, proto3_optional: true, type: :string, json_name: "splitDelimiter"
-  field :trim, 5, proto3_optional: true, type: TrogonProto.Env.V1Alpha1.Trim
-  field :tags, 3, repeated: true, type: TrogonProto.Env.V1Alpha1.EnvVarOption.TagsEntry, map: true
+  field(:visibility, 1, type: TrogonProto.Env.V1Alpha1.Visibility, enum: true)
+  field(:default_value, 2, proto3_optional: true, type: :string, json_name: "defaultValue")
+  field(:split_delimiter, 4, proto3_optional: true, type: :string, json_name: "splitDelimiter")
+  field(:trim, 5, proto3_optional: true, type: TrogonProto.Env.V1Alpha1.Trim)
+  field(:tags, 3, repeated: true, type: TrogonProto.Env.V1Alpha1.EnvVarOption.TagsEntry, map: true)
 end
 
 defmodule TrogonProto.Env.V1Alpha1.FieldOptions do
@@ -360,8 +361,9 @@ defmodule TrogonProto.Env.V1Alpha1.FieldOptions do
     }
   end
 
-  field :env_var, 1,
+  field(:env_var, 1,
     proto3_optional: true,
     type: TrogonProto.Env.V1Alpha1.EnvVarOption,
     json_name: "envVar"
+  )
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/env/v1alpha1/options.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/env/v1alpha1/options.pb.ex
@@ -1,5 +1,11 @@
 defmodule TrogonProto.Env.V1Alpha1.Trim do
-  @moduledoc false
+  @moduledoc """
+  Trim specifies how to remove leading and trailing characters from each value
+  after splitting by `split_delimiter`. Internal characters are never affected.
+
+  INVARIANT: If `trim` is set (present), exactly one of its oneof fields must be set.
+  An empty `Trim` (with `by` unset) is a schema error and must be rejected.
+  """
 
   use Protobuf,
     full_name: "trogon.env.v1alpha1.Trim",
@@ -54,20 +60,17 @@ defmodule TrogonProto.Env.V1Alpha1.Trim do
     }
   end
 
-  oneof(:by, 0)
+  oneof :by, 0
 
-  field(:unicode_whitespace, 1,
+  field :unicode_whitespace, 1,
     type: Google.Protobuf.Empty,
     json_name: "unicodeWhitespace",
     oneof: 0
-  )
 
-  field(:chars, 2, type: :string, oneof: 0)
+  field :chars, 2, type: :string, oneof: 0
 end
 
 defmodule TrogonProto.Env.V1Alpha1.EnvVarOption.TagsEntry do
-  @moduledoc false
-
   use Protobuf,
     full_name: "trogon.env.v1alpha1.EnvVarOption.TagsEntry",
     map: true,
@@ -130,12 +133,14 @@ defmodule TrogonProto.Env.V1Alpha1.EnvVarOption.TagsEntry do
     }
   end
 
-  field(:key, 1, type: :string)
-  field(:value, 2, type: :string)
+  field :key, 1, type: :string
+  field :value, 2, type: :string
 end
 
 defmodule TrogonProto.Env.V1Alpha1.EnvVarOption do
-  @moduledoc false
+  @moduledoc """
+  EnvVarOption captures metadata about an environment variable field.
+  """
 
   use Protobuf,
     full_name: "trogon.env.v1alpha1.EnvVarOption",
@@ -295,15 +300,22 @@ defmodule TrogonProto.Env.V1Alpha1.EnvVarOption do
     }
   end
 
-  field(:visibility, 1, type: TrogonProto.Env.V1Alpha1.Visibility, enum: true)
-  field(:default_value, 2, proto3_optional: true, type: :string, json_name: "defaultValue")
-  field(:split_delimiter, 4, proto3_optional: true, type: :string, json_name: "splitDelimiter")
-  field(:trim, 5, proto3_optional: true, type: TrogonProto.Env.V1Alpha1.Trim)
-  field(:tags, 3, repeated: true, type: TrogonProto.Env.V1Alpha1.EnvVarOption.TagsEntry, map: true)
+  field :visibility, 1, type: TrogonProto.Env.V1Alpha1.Visibility, enum: true
+  field :default_value, 2, proto3_optional: true, type: :string, json_name: "defaultValue"
+  field :split_delimiter, 4, proto3_optional: true, type: :string, json_name: "splitDelimiter"
+  field :trim, 5, proto3_optional: true, type: TrogonProto.Env.V1Alpha1.Trim
+  field :tags, 3, repeated: true, type: TrogonProto.Env.V1Alpha1.EnvVarOption.TagsEntry, map: true
 end
 
 defmodule TrogonProto.Env.V1Alpha1.FieldOptions do
-  @moduledoc false
+  @moduledoc """
+  FieldOptions wraps environment variable metadata.
+  This wrapper pattern allows attaching environment variable metadata
+  to protobuf fields without symbol conflicts (multiple extensions can
+  define different message types without collision).
+
+  Use with `google.protobuf.FieldOptions` extension (see below).
+  """
 
   use Protobuf,
     full_name: "trogon.env.v1alpha1.FieldOptions",
@@ -348,9 +360,8 @@ defmodule TrogonProto.Env.V1Alpha1.FieldOptions do
     }
   end
 
-  field(:env_var, 1,
+  field :env_var, 1,
     proto3_optional: true,
     type: TrogonProto.Env.V1Alpha1.EnvVarOption,
     json_name: "envVar"
-  )
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/env/v1alpha1/visibility.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/env/v1alpha1/visibility.pb.ex
@@ -1,5 +1,14 @@
 defmodule TrogonProto.Env.V1Alpha1.Visibility do
-  @moduledoc false
+  @moduledoc """
+  Visibility controls whether an environment variable value should be
+  masked in generated documentation, .env examples, logs, and CLI output.
+
+  This is a hint to code generators and tooling about how to treat the value
+  when displaying configuration information. The actual secret protection
+  (encryption at rest, masking in memory) must be implemented by consuming code.
+
+  Default (unspecified) is treated as SECRET for safety.
+  """
 
   use Protobuf,
     enum: true,
@@ -38,7 +47,7 @@ defmodule TrogonProto.Env.V1Alpha1.Visibility do
     }
   end
 
-  field(:VISIBILITY_UNSPECIFIED, 0)
-  field(:VISIBILITY_PLAINTEXT, 1)
-  field(:VISIBILITY_SECRET, 2)
+  field :VISIBILITY_UNSPECIFIED, 0
+  field :VISIBILITY_PLAINTEXT, 1
+  field :VISIBILITY_SECRET, 2
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/env/v1alpha1/visibility.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/env/v1alpha1/visibility.pb.ex
@@ -47,7 +47,7 @@ defmodule TrogonProto.Env.V1Alpha1.Visibility do
     }
   end
 
-  field :VISIBILITY_UNSPECIFIED, 0
-  field :VISIBILITY_PLAINTEXT, 1
-  field :VISIBILITY_SECRET, 2
+  field(:VISIBILITY_UNSPECIFIED, 0)
+  field(:VISIBILITY_PLAINTEXT, 1)
+  field(:VISIBILITY_SECRET, 2)
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/error/v1alpha1/code.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/error/v1alpha1/code.pb.ex
@@ -138,21 +138,21 @@ defmodule TrogonProto.Error.V1Alpha1.Code do
     }
   end
 
-  field :UNSPECIFIED, 0
-  field :CANCELLED, 1
-  field :UNKNOWN, 2
-  field :INVALID_ARGUMENT, 3
-  field :DEADLINE_EXCEEDED, 4
-  field :NOT_FOUND, 5
-  field :ALREADY_EXISTS, 6
-  field :PERMISSION_DENIED, 7
-  field :UNAUTHENTICATED, 16
-  field :RESOURCE_EXHAUSTED, 8
-  field :FAILED_PRECONDITION, 9
-  field :ABORTED, 10
-  field :OUT_OF_RANGE, 11
-  field :UNIMPLEMENTED, 12
-  field :INTERNAL, 13
-  field :UNAVAILABLE, 14
-  field :DATA_LOSS, 15
+  field(:UNSPECIFIED, 0)
+  field(:CANCELLED, 1)
+  field(:UNKNOWN, 2)
+  field(:INVALID_ARGUMENT, 3)
+  field(:DEADLINE_EXCEEDED, 4)
+  field(:NOT_FOUND, 5)
+  field(:ALREADY_EXISTS, 6)
+  field(:PERMISSION_DENIED, 7)
+  field(:UNAUTHENTICATED, 16)
+  field(:RESOURCE_EXHAUSTED, 8)
+  field(:FAILED_PRECONDITION, 9)
+  field(:ABORTED, 10)
+  field(:OUT_OF_RANGE, 11)
+  field(:UNIMPLEMENTED, 12)
+  field(:INTERNAL, 13)
+  field(:UNAVAILABLE, 14)
+  field(:DATA_LOSS, 15)
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/error/v1alpha1/code.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/error/v1alpha1/code.pb.ex
@@ -1,5 +1,21 @@
 defmodule TrogonProto.Error.V1Alpha1.Code do
-  @moduledoc false
+  @moduledoc """
+  The canonical error codes for gRPC APIs.
+
+  This enum mirrors the error values from `google.rpc.Code` so typed error
+  templates can point at the canonical Google RPC error space without
+  importing `google.rpc`.
+
+  `OK` is intentionally omitted because this enum is used only for errors.
+
+  Sometimes multiple error codes may apply. Services should return the most
+  specific error code that applies. For example, prefer `OUT_OF_RANGE` over
+  `FAILED_PRECONDITION` if both codes apply. Similarly prefer `NOT_FOUND` or
+  `ALREADY_EXISTS` over `FAILED_PRECONDITION`.
+
+  Source:
+  https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
+  """
 
   use Protobuf,
     enum: true,
@@ -122,21 +138,21 @@ defmodule TrogonProto.Error.V1Alpha1.Code do
     }
   end
 
-  field(:UNSPECIFIED, 0)
-  field(:CANCELLED, 1)
-  field(:UNKNOWN, 2)
-  field(:INVALID_ARGUMENT, 3)
-  field(:DEADLINE_EXCEEDED, 4)
-  field(:NOT_FOUND, 5)
-  field(:ALREADY_EXISTS, 6)
-  field(:PERMISSION_DENIED, 7)
-  field(:UNAUTHENTICATED, 16)
-  field(:RESOURCE_EXHAUSTED, 8)
-  field(:FAILED_PRECONDITION, 9)
-  field(:ABORTED, 10)
-  field(:OUT_OF_RANGE, 11)
-  field(:UNIMPLEMENTED, 12)
-  field(:INTERNAL, 13)
-  field(:UNAVAILABLE, 14)
-  field(:DATA_LOSS, 15)
+  field :UNSPECIFIED, 0
+  field :CANCELLED, 1
+  field :UNKNOWN, 2
+  field :INVALID_ARGUMENT, 3
+  field :DEADLINE_EXCEEDED, 4
+  field :NOT_FOUND, 5
+  field :ALREADY_EXISTS, 6
+  field :PERMISSION_DENIED, 7
+  field :UNAUTHENTICATED, 16
+  field :RESOURCE_EXHAUSTED, 8
+  field :FAILED_PRECONDITION, 9
+  field :ABORTED, 10
+  field :OUT_OF_RANGE, 11
+  field :UNIMPLEMENTED, 12
+  field :INTERNAL, 13
+  field :UNAVAILABLE, 14
+  field :DATA_LOSS, 15
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/error/v1alpha1/options.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/error/v1alpha1/options.pb.ex
@@ -1,5 +1,12 @@
 defmodule TrogonProto.Error.V1Alpha1.MessageOptions.Template do
-  @moduledoc false
+  @moduledoc """
+  Template defines the static error template for a message that can be
+  adapted into a runtime error representation.
+
+  These fields are intentionally language-neutral so both Elixir and Go
+  runtimes can derive their native error template APIs from the same proto
+  annotation.
+  """
 
   use Protobuf,
     full_name: "trogon.error.v1alpha1.MessageOptions.Template",
@@ -97,14 +104,16 @@ defmodule TrogonProto.Error.V1Alpha1.MessageOptions.Template do
     }
   end
 
-  field(:domain, 1, proto3_optional: true, type: :string)
-  field(:reason, 2, proto3_optional: true, type: :string)
-  field(:message, 3, proto3_optional: true, type: :string)
-  field(:code, 4, proto3_optional: true, type: TrogonProto.Error.V1Alpha1.Code, enum: true)
+  field :domain, 1, proto3_optional: true, type: :string
+  field :reason, 2, proto3_optional: true, type: :string
+  field :message, 3, proto3_optional: true, type: :string
+  field :code, 4, proto3_optional: true, type: TrogonProto.Error.V1Alpha1.Code, enum: true
 end
 
 defmodule TrogonProto.Error.V1Alpha1.MessageOptions do
-  @moduledoc false
+  @moduledoc """
+  MessageOptions defines message-level options for error payload messages.
+  """
 
   use Protobuf,
     full_name: "trogon.error.v1alpha1.MessageOptions",
@@ -235,5 +244,5 @@ defmodule TrogonProto.Error.V1Alpha1.MessageOptions do
     }
   end
 
-  field(:template, 1, type: TrogonProto.Error.V1Alpha1.MessageOptions.Template)
+  field :template, 1, type: TrogonProto.Error.V1Alpha1.MessageOptions.Template
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/error/v1alpha1/options.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/error/v1alpha1/options.pb.ex
@@ -104,10 +104,10 @@ defmodule TrogonProto.Error.V1Alpha1.MessageOptions.Template do
     }
   end
 
-  field :domain, 1, proto3_optional: true, type: :string
-  field :reason, 2, proto3_optional: true, type: :string
-  field :message, 3, proto3_optional: true, type: :string
-  field :code, 4, proto3_optional: true, type: TrogonProto.Error.V1Alpha1.Code, enum: true
+  field(:domain, 1, proto3_optional: true, type: :string)
+  field(:reason, 2, proto3_optional: true, type: :string)
+  field(:message, 3, proto3_optional: true, type: :string)
+  field(:code, 4, proto3_optional: true, type: TrogonProto.Error.V1Alpha1.Code, enum: true)
 end
 
 defmodule TrogonProto.Error.V1Alpha1.MessageOptions do
@@ -244,5 +244,5 @@ defmodule TrogonProto.Error.V1Alpha1.MessageOptions do
     }
   end
 
-  field :template, 1, type: TrogonProto.Error.V1Alpha1.MessageOptions.Template
+  field(:template, 1, type: TrogonProto.Error.V1Alpha1.MessageOptions.Template)
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/object_id/v1alpha1/options.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/object_id/v1alpha1/options.pb.ex
@@ -60,6 +60,6 @@ defmodule TrogonProto.ObjectId.V1Alpha1.EnumValueOptions do
     }
   end
 
-  field :object_type, 1, type: :string, json_name: "objectType"
-  field :separator, 2, proto3_optional: true, type: :string
+  field(:object_type, 1, type: :string, json_name: "objectType")
+  field(:separator, 2, proto3_optional: true, type: :string)
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/object_id/v1alpha1/options.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/object_id/v1alpha1/options.pb.ex
@@ -1,5 +1,7 @@
 defmodule TrogonProto.ObjectId.V1Alpha1.EnumValueOptions do
-  @moduledoc false
+  @moduledoc """
+  EnumValueOptions defines enum-value-level options for object ID types.
+  """
 
   use Protobuf,
     full_name: "trogon.object_id.v1alpha1.EnumValueOptions",
@@ -58,6 +60,6 @@ defmodule TrogonProto.ObjectId.V1Alpha1.EnumValueOptions do
     }
   end
 
-  field(:object_type, 1, type: :string, json_name: "objectType")
-  field(:separator, 2, proto3_optional: true, type: :string)
+  field :object_type, 1, type: :string, json_name: "objectType"
+  field :separator, 2, proto3_optional: true, type: :string
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/relay/v1alpha1/cursor_pagination.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/relay/v1alpha1/cursor_pagination.pb.ex
@@ -60,8 +60,8 @@ defmodule TrogonProto.Relay.V1Alpha1.CursorPagination.Forward do
     }
   end
 
-  field :first, 1, type: :uint32
-  field :after, 2, proto3_optional: true, type: :string
+  field(:first, 1, type: :uint32)
+  field(:after, 2, proto3_optional: true, type: :string)
 end
 
 defmodule TrogonProto.Relay.V1Alpha1.CursorPagination.Backward do
@@ -126,8 +126,8 @@ defmodule TrogonProto.Relay.V1Alpha1.CursorPagination.Backward do
     }
   end
 
-  field :last, 1, type: :uint32
-  field :before, 2, proto3_optional: true, type: :string
+  field(:last, 1, type: :uint32)
+  field(:before, 2, proto3_optional: true, type: :string)
 end
 
 defmodule TrogonProto.Relay.V1Alpha1.CursorPagination do
@@ -304,8 +304,8 @@ defmodule TrogonProto.Relay.V1Alpha1.CursorPagination do
     }
   end
 
-  oneof :direction, 0
+  oneof(:direction, 0)
 
-  field :forward, 1, type: TrogonProto.Relay.V1Alpha1.CursorPagination.Forward, oneof: 0
-  field :backward, 2, type: TrogonProto.Relay.V1Alpha1.CursorPagination.Backward, oneof: 0
+  field(:forward, 1, type: TrogonProto.Relay.V1Alpha1.CursorPagination.Forward, oneof: 0)
+  field(:backward, 2, type: TrogonProto.Relay.V1Alpha1.CursorPagination.Backward, oneof: 0)
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/relay/v1alpha1/cursor_pagination.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/relay/v1alpha1/cursor_pagination.pb.ex
@@ -1,5 +1,7 @@
 defmodule TrogonProto.Relay.V1Alpha1.CursorPagination.Forward do
-  @moduledoc false
+  @moduledoc """
+  Forward specifies parameters for forward pagination direction.
+  """
 
   use Protobuf,
     full_name: "trogon.relay.v1alpha1.CursorPagination.Forward",
@@ -58,12 +60,14 @@ defmodule TrogonProto.Relay.V1Alpha1.CursorPagination.Forward do
     }
   end
 
-  field(:first, 1, type: :uint32)
-  field(:after, 2, proto3_optional: true, type: :string)
+  field :first, 1, type: :uint32
+  field :after, 2, proto3_optional: true, type: :string
 end
 
 defmodule TrogonProto.Relay.V1Alpha1.CursorPagination.Backward do
-  @moduledoc false
+  @moduledoc """
+  Backward specifies parameters for backward pagination direction.
+  """
 
   use Protobuf,
     full_name: "trogon.relay.v1alpha1.CursorPagination.Backward",
@@ -122,12 +126,29 @@ defmodule TrogonProto.Relay.V1Alpha1.CursorPagination.Backward do
     }
   end
 
-  field(:last, 1, type: :uint32)
-  field(:before, 2, proto3_optional: true, type: :string)
+  field :last, 1, type: :uint32
+  field :before, 2, proto3_optional: true, type: :string
 end
 
 defmodule TrogonProto.Relay.V1Alpha1.CursorPagination do
-  @moduledoc false
+  @moduledoc """
+  CursorPagination represents cursor-based pagination parameters.
+
+  Use this message to specify pagination parameters in list query requests
+  following the Relay specification.
+
+  Enforces Relay constraints:
+  - Exactly one of Forward or Backward must be specified
+  - Parameters for each direction are logically grouped
+
+  Example usage:
+
+    import "trogon/relay/v1alpha1/cursor_pagination.proto";
+
+    message ListUsersRequest {
+      trogon.relay.v1alpha1.CursorPagination pagination = 1;
+    }
+  """
 
   use Protobuf,
     full_name: "trogon.relay.v1alpha1.CursorPagination",
@@ -283,8 +304,8 @@ defmodule TrogonProto.Relay.V1Alpha1.CursorPagination do
     }
   end
 
-  oneof(:direction, 0)
+  oneof :direction, 0
 
-  field(:forward, 1, type: TrogonProto.Relay.V1Alpha1.CursorPagination.Forward, oneof: 0)
-  field(:backward, 2, type: TrogonProto.Relay.V1Alpha1.CursorPagination.Backward, oneof: 0)
+  field :forward, 1, type: TrogonProto.Relay.V1Alpha1.CursorPagination.Forward, oneof: 0
+  field :backward, 2, type: TrogonProto.Relay.V1Alpha1.CursorPagination.Backward, oneof: 0
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/relay/v1alpha1/page_info.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/relay/v1alpha1/page_info.pb.ex
@@ -1,5 +1,19 @@
 defmodule TrogonProto.Relay.V1Alpha1.PageInfo do
-  @moduledoc false
+  @moduledoc """
+  PageInfo provides cursor-based pagination information for Relay connections.
+
+  This message follows the Relay GraphQL Connection specification and contains
+  metadata about the current page in a cursor-paginated result set.
+
+  Example usage:
+
+    import "trogon/relay/v1alpha1/page_info.proto";
+
+    message UserConnection {
+      repeated UserEdge edges = 1;
+      trogon.relay.v1alpha1.PageInfo page_info = 2;
+    }
+  """
 
   use Protobuf,
     full_name: "trogon.relay.v1alpha1.PageInfo",
@@ -91,8 +105,8 @@ defmodule TrogonProto.Relay.V1Alpha1.PageInfo do
     }
   end
 
-  field(:has_next_page, 1, type: :bool, json_name: "hasNextPage")
-  field(:has_previous_page, 2, type: :bool, json_name: "hasPreviousPage")
-  field(:start_cursor, 3, proto3_optional: true, type: :string, json_name: "startCursor")
-  field(:end_cursor, 4, proto3_optional: true, type: :string, json_name: "endCursor")
+  field :has_next_page, 1, type: :bool, json_name: "hasNextPage"
+  field :has_previous_page, 2, type: :bool, json_name: "hasPreviousPage"
+  field :start_cursor, 3, proto3_optional: true, type: :string, json_name: "startCursor"
+  field :end_cursor, 4, proto3_optional: true, type: :string, json_name: "endCursor"
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/relay/v1alpha1/page_info.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/relay/v1alpha1/page_info.pb.ex
@@ -105,8 +105,8 @@ defmodule TrogonProto.Relay.V1Alpha1.PageInfo do
     }
   end
 
-  field :has_next_page, 1, type: :bool, json_name: "hasNextPage"
-  field :has_previous_page, 2, type: :bool, json_name: "hasPreviousPage"
-  field :start_cursor, 3, proto3_optional: true, type: :string, json_name: "startCursor"
-  field :end_cursor, 4, proto3_optional: true, type: :string, json_name: "endCursor"
+  field(:has_next_page, 1, type: :bool, json_name: "hasNextPage")
+  field(:has_previous_page, 2, type: :bool, json_name: "hasPreviousPage")
+  field(:start_cursor, 3, proto3_optional: true, type: :string, json_name: "startCursor")
+  field(:end_cursor, 4, proto3_optional: true, type: :string, json_name: "endCursor")
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/stream/v1alpha1/options.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/stream/v1alpha1/options.pb.ex
@@ -60,6 +60,6 @@ defmodule TrogonProto.Stream.V1Alpha1.EnumValueOptions do
     }
   end
 
-  field :prefix, 1, type: :string
-  field :separator, 2, proto3_optional: true, type: :string
+  field(:prefix, 1, type: :string)
+  field(:separator, 2, proto3_optional: true, type: :string)
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/stream/v1alpha1/options.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/stream/v1alpha1/options.pb.ex
@@ -1,5 +1,7 @@
 defmodule TrogonProto.Stream.V1Alpha1.EnumValueOptions do
-  @moduledoc false
+  @moduledoc """
+  EnumValueOptions defines enum-value-level options for stream identity prefixes.
+  """
 
   use Protobuf,
     full_name: "trogon.stream.v1alpha1.EnumValueOptions",
@@ -58,6 +60,6 @@ defmodule TrogonProto.Stream.V1Alpha1.EnumValueOptions do
     }
   end
 
-  field(:prefix, 1, type: :string)
-  field(:separator, 2, proto3_optional: true, type: :string)
+  field :prefix, 1, type: :string
+  field :separator, 2, proto3_optional: true, type: :string
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/uuid/v1/namespace.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/uuid/v1/namespace.pb.ex
@@ -70,9 +70,9 @@ defmodule TrogonProto.Uuid.V1.Namespace do
     }
   end
 
-  oneof :value, 0
+  oneof(:value, 0)
 
-  field :uuid, 1, type: :string, oneof: 0
-  field :dns, 2, type: :string, oneof: 0
-  field :url, 3, type: :string, oneof: 0
+  field(:uuid, 1, type: :string, oneof: 0)
+  field(:dns, 2, type: :string, oneof: 0)
+  field(:url, 3, type: :string, oneof: 0)
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/uuid/v1/namespace.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/uuid/v1/namespace.pb.ex
@@ -1,5 +1,7 @@
 defmodule TrogonProto.Uuid.V1.Namespace do
-  @moduledoc false
+  @moduledoc """
+  Namespace defines the namespace for UUIDv5 generation.
+  """
 
   use Protobuf,
     full_name: "trogon.uuid.v1.Namespace",
@@ -68,9 +70,9 @@ defmodule TrogonProto.Uuid.V1.Namespace do
     }
   end
 
-  oneof(:value, 0)
+  oneof :value, 0
 
-  field(:uuid, 1, type: :string, oneof: 0)
-  field(:dns, 2, type: :string, oneof: 0)
-  field(:url, 3, type: :string, oneof: 0)
+  field :uuid, 1, type: :string, oneof: 0
+  field :dns, 2, type: :string, oneof: 0
+  field :url, 3, type: :string, oneof: 0
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/uuid/v1/options.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/uuid/v1/options.pb.ex
@@ -1,5 +1,7 @@
 defmodule TrogonProto.Uuid.V1.EnumOptions do
-  @moduledoc false
+  @moduledoc """
+  EnumOptions defines enum-level options for UUID generation.
+  """
 
   use Protobuf,
     full_name: "trogon.uuid.v1.EnumOptions",
@@ -44,11 +46,14 @@ defmodule TrogonProto.Uuid.V1.EnumOptions do
     }
   end
 
-  field(:namespace, 1, proto3_optional: true, type: TrogonProto.Uuid.V1.Namespace)
+  field :namespace, 1, proto3_optional: true, type: TrogonProto.Uuid.V1.Namespace
 end
 
 defmodule TrogonProto.Uuid.V1.EnumValueOptions.Format do
-  @moduledoc false
+  @moduledoc """
+  Format defines the UUID generation parameters.
+  Nested to avoid conflicts with potential top-level Format messages.
+  """
 
   use Protobuf,
     full_name: "trogon.uuid.v1.EnumValueOptions.Format",
@@ -107,12 +112,14 @@ defmodule TrogonProto.Uuid.V1.EnumValueOptions.Format do
     }
   end
 
-  field(:namespace, 1, proto3_optional: true, type: TrogonProto.Uuid.V1.Namespace)
-  field(:template, 2, type: :string)
+  field :namespace, 1, proto3_optional: true, type: TrogonProto.Uuid.V1.Namespace
+  field :template, 2, type: :string
 end
 
 defmodule TrogonProto.Uuid.V1.EnumValueOptions do
-  @moduledoc false
+  @moduledoc """
+  EnumValueOptions defines enum-value-level options for UUID generation.
+  """
 
   use Protobuf,
     full_name: "trogon.uuid.v1.EnumValueOptions",
@@ -206,5 +213,5 @@ defmodule TrogonProto.Uuid.V1.EnumValueOptions do
     }
   end
 
-  field(:format, 1, proto3_optional: true, type: TrogonProto.Uuid.V1.EnumValueOptions.Format)
+  field :format, 1, proto3_optional: true, type: TrogonProto.Uuid.V1.EnumValueOptions.Format
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/uuid/v1/options.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/uuid/v1/options.pb.ex
@@ -46,7 +46,7 @@ defmodule TrogonProto.Uuid.V1.EnumOptions do
     }
   end
 
-  field :namespace, 1, proto3_optional: true, type: TrogonProto.Uuid.V1.Namespace
+  field(:namespace, 1, proto3_optional: true, type: TrogonProto.Uuid.V1.Namespace)
 end
 
 defmodule TrogonProto.Uuid.V1.EnumValueOptions.Format do
@@ -112,8 +112,8 @@ defmodule TrogonProto.Uuid.V1.EnumValueOptions.Format do
     }
   end
 
-  field :namespace, 1, proto3_optional: true, type: TrogonProto.Uuid.V1.Namespace
-  field :template, 2, type: :string
+  field(:namespace, 1, proto3_optional: true, type: TrogonProto.Uuid.V1.Namespace)
+  field(:template, 2, type: :string)
 end
 
 defmodule TrogonProto.Uuid.V1.EnumValueOptions do
@@ -213,5 +213,5 @@ defmodule TrogonProto.Uuid.V1.EnumValueOptions do
     }
   end
 
-  field :format, 1, proto3_optional: true, type: TrogonProto.Uuid.V1.EnumValueOptions.Format
+  field(:format, 1, proto3_optional: true, type: TrogonProto.Uuid.V1.EnumValueOptions.Format)
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/uuid/v1/uuid.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/uuid/v1/uuid.pb.ex
@@ -52,5 +52,5 @@ defmodule TrogonProto.Uuid.V1.Uuid do
     }
   end
 
-  field :value, 1, type: :string
+  field(:value, 1, type: :string)
 end

--- a/apps/trogon_proto/lib/__generated__/trogon/uuid/v1/uuid.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/uuid/v1/uuid.pb.ex
@@ -1,5 +1,19 @@
 defmodule TrogonProto.Uuid.V1.Uuid do
-  @moduledoc false
+  @moduledoc """
+  Uuid represents a universally unique identifier.
+
+  Use this message type instead of raw strings for type-safe UUID fields.
+  The version can be extracted from character 15 (0-indexed: 14) of the value.
+
+  Example usage:
+
+    import "trogon/uuid/v1/uuid.proto";
+
+    message Order {
+      trogon.uuid.v1.Uuid id = 1;
+      string customer_name = 2;
+    }
+  """
 
   use Protobuf,
     full_name: "trogon.uuid.v1.Uuid",
@@ -38,5 +52,5 @@ defmodule TrogonProto.Uuid.V1.Uuid do
     }
   end
 
-  field(:value, 1, type: :string)
+  field :value, 1, type: :string
 end

--- a/apps/trogon_proto/lib/__generated__/trogon_proto/env/v1_alpha1/pb_extension.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon_proto/env/v1_alpha1/pb_extension.pb.ex
@@ -1,7 +1,8 @@
 defmodule TrogonProto.Env.V1Alpha1.PbExtension do
   use Protobuf, protoc_gen_elixir_version: "0.16.0"
 
-  extend Google.Protobuf.FieldOptions, :field, 870_003,
+  extend(Google.Protobuf.FieldOptions, :field, 870_003,
     optional: true,
     type: TrogonProto.Env.V1Alpha1.FieldOptions
+  )
 end

--- a/apps/trogon_proto/lib/__generated__/trogon_proto/env/v1_alpha1/pb_extension.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon_proto/env/v1_alpha1/pb_extension.pb.ex
@@ -1,10 +1,7 @@
 defmodule TrogonProto.Env.V1Alpha1.PbExtension do
-  @moduledoc false
-
   use Protobuf, protoc_gen_elixir_version: "0.16.0"
 
-  extend(Google.Protobuf.FieldOptions, :field, 870_003,
+  extend Google.Protobuf.FieldOptions, :field, 870_003,
     optional: true,
     type: TrogonProto.Env.V1Alpha1.FieldOptions
-  )
 end

--- a/apps/trogon_proto/lib/__generated__/trogon_proto/error/v1_alpha1/pb_extension.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon_proto/error/v1_alpha1/pb_extension.pb.ex
@@ -1,7 +1,8 @@
 defmodule TrogonProto.Error.V1Alpha1.PbExtension do
   use Protobuf, protoc_gen_elixir_version: "0.16.0"
 
-  extend Google.Protobuf.MessageOptions, :message, 870_012,
+  extend(Google.Protobuf.MessageOptions, :message, 870_012,
     optional: true,
     type: TrogonProto.Error.V1Alpha1.MessageOptions
+  )
 end

--- a/apps/trogon_proto/lib/__generated__/trogon_proto/error/v1_alpha1/pb_extension.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon_proto/error/v1_alpha1/pb_extension.pb.ex
@@ -1,10 +1,7 @@
 defmodule TrogonProto.Error.V1Alpha1.PbExtension do
-  @moduledoc false
-
   use Protobuf, protoc_gen_elixir_version: "0.16.0"
 
-  extend(Google.Protobuf.MessageOptions, :message, 870_012,
+  extend Google.Protobuf.MessageOptions, :message, 870_012,
     optional: true,
     type: TrogonProto.Error.V1Alpha1.MessageOptions
-  )
 end

--- a/apps/trogon_proto/lib/__generated__/trogon_proto/object_id/v1_alpha1/pb_extension.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon_proto/object_id/v1_alpha1/pb_extension.pb.ex
@@ -1,8 +1,9 @@
 defmodule TrogonProto.ObjectId.V1Alpha1.PbExtension do
   use Protobuf, protoc_gen_elixir_version: "0.16.0"
 
-  extend Google.Protobuf.EnumValueOptions, :enum_value, 870_010,
+  extend(Google.Protobuf.EnumValueOptions, :enum_value, 870_010,
     optional: true,
     type: TrogonProto.ObjectId.V1Alpha1.EnumValueOptions,
     json_name: "enumValue"
+  )
 end

--- a/apps/trogon_proto/lib/__generated__/trogon_proto/object_id/v1_alpha1/pb_extension.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon_proto/object_id/v1_alpha1/pb_extension.pb.ex
@@ -1,11 +1,8 @@
 defmodule TrogonProto.ObjectId.V1Alpha1.PbExtension do
-  @moduledoc false
-
   use Protobuf, protoc_gen_elixir_version: "0.16.0"
 
-  extend(Google.Protobuf.EnumValueOptions, :enum_value, 870_010,
+  extend Google.Protobuf.EnumValueOptions, :enum_value, 870_010,
     optional: true,
     type: TrogonProto.ObjectId.V1Alpha1.EnumValueOptions,
     json_name: "enumValue"
-  )
 end

--- a/apps/trogon_proto/lib/__generated__/trogon_proto/stream/v1_alpha1/pb_extension.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon_proto/stream/v1_alpha1/pb_extension.pb.ex
@@ -1,11 +1,8 @@
 defmodule TrogonProto.Stream.V1Alpha1.PbExtension do
-  @moduledoc false
-
   use Protobuf, protoc_gen_elixir_version: "0.16.0"
 
-  extend(Google.Protobuf.EnumValueOptions, :enum_value, 870_011,
+  extend Google.Protobuf.EnumValueOptions, :enum_value, 870_011,
     optional: true,
     type: TrogonProto.Stream.V1Alpha1.EnumValueOptions,
     json_name: "enumValue"
-  )
 end

--- a/apps/trogon_proto/lib/__generated__/trogon_proto/stream/v1_alpha1/pb_extension.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon_proto/stream/v1_alpha1/pb_extension.pb.ex
@@ -1,8 +1,9 @@
 defmodule TrogonProto.Stream.V1Alpha1.PbExtension do
   use Protobuf, protoc_gen_elixir_version: "0.16.0"
 
-  extend Google.Protobuf.EnumValueOptions, :enum_value, 870_011,
+  extend(Google.Protobuf.EnumValueOptions, :enum_value, 870_011,
     optional: true,
     type: TrogonProto.Stream.V1Alpha1.EnumValueOptions,
     json_name: "enumValue"
+  )
 end

--- a/apps/trogon_proto/lib/__generated__/trogon_proto/uuid/v1/pb_extension.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon_proto/uuid/v1/pb_extension.pb.ex
@@ -1,12 +1,14 @@
 defmodule TrogonProto.Uuid.V1.PbExtension do
   use Protobuf, protoc_gen_elixir_version: "0.16.0"
 
-  extend Google.Protobuf.EnumOptions, :enum, 870_001,
+  extend(Google.Protobuf.EnumOptions, :enum, 870_001,
     optional: true,
     type: TrogonProto.Uuid.V1.EnumOptions
+  )
 
-  extend Google.Protobuf.EnumValueOptions, :enum_value, 870_002,
+  extend(Google.Protobuf.EnumValueOptions, :enum_value, 870_002,
     optional: true,
     type: TrogonProto.Uuid.V1.EnumValueOptions,
     json_name: "enumValue"
+  )
 end

--- a/apps/trogon_proto/lib/__generated__/trogon_proto/uuid/v1/pb_extension.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon_proto/uuid/v1/pb_extension.pb.ex
@@ -1,16 +1,12 @@
 defmodule TrogonProto.Uuid.V1.PbExtension do
-  @moduledoc false
-
   use Protobuf, protoc_gen_elixir_version: "0.16.0"
 
-  extend(Google.Protobuf.EnumOptions, :enum, 870_001,
+  extend Google.Protobuf.EnumOptions, :enum, 870_001,
     optional: true,
     type: TrogonProto.Uuid.V1.EnumOptions
-  )
 
-  extend(Google.Protobuf.EnumValueOptions, :enum_value, 870_002,
+  extend Google.Protobuf.EnumValueOptions, :enum_value, 870_002,
     optional: true,
     type: TrogonProto.Uuid.V1.EnumValueOptions,
     json_name: "enumValue"
-  )
 end


### PR DESCRIPTION
- Generated protobuf modules defaulted to `@moduledoc false`, causing ExDoc warnings when downstream packages referenced their types in specs and docs