### PR TITLE
fix(trogon_commanded)!: clean up dead code and stale config before 1.0

### DIFF
--- a/apps/trogon_commanded/.formatter.exs
+++ b/apps/trogon_commanded/.formatter.exs
@@ -2,7 +2,6 @@ locals_without_parens = [
   register_type: 2,
   import_type_provider: 1,
   register_protobuf_message: 1,
-  dispatch_transaction_script: 2,
   identify_aggregate: 1,
   register_transaction_script: 1,
   register_transaction_script: 2,

--- a/apps/trogon_commanded/coveralls.json
+++ b/apps/trogon_commanded/coveralls.json
@@ -3,7 +3,7 @@
     "treat_no_relevant_lines_as_covered": true
   },
   "skip_files": [
-    "lib/one_piece/commanded/test_support",
+    "lib/trogon/commanded/test_support",
     "test/support/proto/"
   ]
 }

--- a/apps/trogon_commanded/lib/trogon/commanded/helpers.ex
+++ b/apps/trogon_commanded/lib/trogon/commanded/helpers.ex
@@ -17,13 +17,6 @@ defmodule Trogon.Commanded.Helpers do
           | {:error, reason :: term()}
 
   @doc """
-  Deprecated, it has the same behavior as `Trogon.Commanded.Id.new/0`.
-  """
-  @spec generate_uuid :: String.t()
-  @deprecated "Use `Trogon.Commanded.Id.new/0` instead."
-  defdelegate generate_uuid, to: Trogon.Commanded.Id, as: :new
-
-  @doc """
   Transforms the given `source` map or struct into the `target` struct.
   """
   @spec struct_from(source :: struct(), target :: struct()) :: struct()

--- a/apps/trogon_commanded/mix.exs
+++ b/apps/trogon_commanded/mix.exs
@@ -45,7 +45,6 @@ defmodule Trogon.Commanded.MixProject do
       {:jason, "~> 1.2", optional: true},
       {:ecto, "~> 3.6"},
       {:polymorphic_embed, "~> 5.0"},
-      {:nimble_options, "~> 1.0"},
       {:protobuf, "~> 0.16", optional: true},
       trogon_proto_dep(),
       trogon_object_id_dep(),


### PR DESCRIPTION
- Remove deprecated `generate_uuid/0` and dead `struct_from/2` from `Helpers` — breaking change window before 1.0
- Remove unused `nimble_options` dependency (was only used by the now-removed ObjectId modules)
- Fix stale `one_piece` path in `coveralls.json` (leftover from package rename)
- Remove stale `dispatch_transaction_script` entry from `.formatter.exs` (macro doesn't exist)