### PR TITLE
chore: add Diataxis-style README introductions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # BEAM Monorepo
+
+**An Elixir umbrella repository housing shared libraries for building event-sourced, protobuf-driven BEAM applications.**
+
+**This monorepo contains packages for structured error handling (`trogon_error`), result type combinators (`trogon_result`), Commanded CQRS/ES extensions (`trogon_commanded`), protobuf schema integration (`trogon_proto`), typed object IDs (`trogon_object_id`), compile-time type providers (`trogon_typeprovider`), and Kubernetes-aware graceful shutdown (`one_piece_graceful_shutdown`).**
+
+**Managing these foundational libraries in separate repositories leads to fragmented CI, version drift, and cross-cutting changes that span multiple PRs. The umbrella structure keeps shared dependencies aligned, enables atomic cross-package changes, and provides a single test and release pipeline.**
+
+**This monorepo is maintained by the Straw Hat Team for Elixir engineers building distributed, event-sourced services that share contracts, conventions, and infrastructure primitives across the platform.**

--- a/apps/one_piece_graceful_shutdown/README.md
+++ b/apps/one_piece_graceful_shutdown/README.md
@@ -1,6 +1,12 @@
 # OnePiece.GracefulShutdown
 
-Catches `SIGTERM` signal to gracefully stop the system.
+**An Elixir library that intercepts SIGTERM to give your BEAM application a controlled, two-phase graceful shutdown.**
+
+**OnePiece.GracefulShutdown hooks into the Erlang VM's signal server, transitions the application into a draining state that makes readiness probes return HTTP 503, waits a configurable delay for in-flight requests to complete, and then initiates an orderly `System.stop/0`. It includes a Plug-based readiness probe endpoint out of the box.**
+
+**Container orchestrators like Kubernetes send SIGTERM before killing pods, but the BEAM does not cooperate with that signal by default — it may terminate mid-request, dropping live connections and losing in-flight work. This library bridges that gap so load balancers stop routing traffic before the VM shuts down.**
+
+**OnePiece.GracefulShutdown is built for Elixir teams running on Kubernetes or similar orchestration platforms that use rolling deploys, horizontal autoscaling, or any scenario where pods are replaced and zero-downtime draining is required.**
 
 ## Documentation
 

--- a/apps/trogon_commanded/README.md
+++ b/apps/trogon_commanded/README.md
@@ -1,6 +1,12 @@
 # Trogon.Commanded
 
-Extend `Commanded` package. A swiss army knife for applications following Domain-Driven Design (DDD), Event Sourcing (ES), and Command and Query Responsibility Segregation (CQRS).
+**An opinionated extension layer for the Commanded framework that provides macros, conventions, and building blocks for Domain-Driven Design, Event Sourcing, and CQRS in Elixir.**
+
+**Trogon.Commanded supplies `use`-able modules for defining aggregates, commands, events, value objects, and enums as Ecto embedded schemas with built-in validation, JSON encoding, and factory functions. It enforces a one-command-per-handler Transaction Script pattern via `register_transaction_script`, ships Protobuf-aware and JSONB event store serializers, a compile-time type provider registry, read-after-write consistency policies for the query side, and an infrastructure-free test case template for pure command handler testing.**
+
+**The raw Commanded library provides the mechanics of event sourcing but leaves structural decisions — how to define domain types, wire up routing, serialize events, enforce stream identity naming, handle eventual consistency, and test handlers in isolation — entirely to the developer. Trogon.Commanded fills that gap with a cohesive set of conventions that eliminate boilerplate and prevent common pitfalls like God Object aggregates and stale in-memory processes.**
+
+**Trogon.Commanded is built for Elixir teams that use Commanded as their CQRS/ES framework, follow Domain-Driven Design, store events in PostgreSQL as JSONB, and want strongly-typed domain structs with Ecto validation without requiring a full Ecto Repo.**
 
 ## Documentation
 

--- a/apps/trogon_error/README.md
+++ b/apps/trogon_error/README.md
@@ -1,5 +1,13 @@
 # Trogon.Error
 
+**A structured error library for Elixir that treats errors as typed values with domain-scoped identity, metadata, and visibility controls.**
+
+**Trogon.Error lets you define error modules using `use Trogon.Error` with a domain, reason, code, and message. Each error carries Google RPC-compatible status codes, visibility levels, structured metadata with per-field visibility, localization support, retry information, and help links. Errors can also be created dynamically at runtime for handling external service failures.**
+
+**Applications that cross service boundaries, expose APIs, or feed errors into monitoring pipelines need errors that are machine-parseable, consistently shaped, and safe to surface to different audiences. Trogon.Error enforces compile-time message contracts and metadata visibility so that internal details never leak to end users by accident.**
+
+**Trogon.Error is built for Elixir teams that operate distributed systems, build public or internal APIs, or need structured error contracts that integrate cleanly with gRPC, REST, and observability tooling.**
+
 ## Documentation
 
 ### References

--- a/apps/trogon_proto/README.md
+++ b/apps/trogon_proto/README.md
@@ -1,6 +1,12 @@
 # Trogon.Proto
 
-Protobuf compilation and extensions integration.
+**An Elixir runtime and integration layer for the trogon-proto Buf Schema Registry that ships pre-compiled protobuf modules and compile-time macros for schema-driven code generation.**
+
+**Trogon.Proto provides two main macros: `Trogon.Proto.Env` reads proto field annotations to generate typed, secret-safe environment variable loaders with automatic type conversion and masked `Inspect` output; and `Trogon.Proto.Uuid.V1.UuidTemplate` reads proto enum annotations to generate deterministic UUIDv5 identity functions from versioned templates. It also ships shared proto message contracts for Relay cursor pagination, CQRS read-your-writes consistency, structured error templates, typed UUIDs, stream identity, and object ID prefixes.**
+
+**Teams using protobuf as a cross-language contract layer accumulate boilerplate around environment config loading, deterministic ID generation, and shared primitives like pagination and consistency. Trogon.Proto encodes those conventions directly in the proto schema as custom extensions and generates correct Elixir code at compile time — eliminating drift between the schema definition and runtime behavior.**
+
+**Trogon.Proto is built for Elixir teams that use protobuf as their service contract layer and need schema-driven code generation for config, identity, and shared API primitives across gRPC or event-driven architectures.**
 
 ## Documentation
 

--- a/apps/trogon_result/README.md
+++ b/apps/trogon_result/README.md
@@ -1,6 +1,12 @@
 # Trogon.Result
 
-Handles `t:Trogon.Result.t/0` responses. Inspired by Rust `std::result::Result` package.
+**A zero-dependency Elixir library that provides a composable, pipe-friendly API for working with `{:ok, value}` / `{:error, reason}` tuples, inspired by Rust's `std::result::Result`.**
+
+**Trogon.Result offers construction helpers, predicate checks, guards usable in function heads, ok-side and error-side transformations, short-circuit combinators, side-effect taps for observability, safe and raising unwrap variants, nil rejection, result flattening, and list collection into a single result. Every function is designed to chain cleanly in pipelines.**
+
+**Elixir code that chains operations returning result tuples often accumulates repetitive pattern-matching boilerplate and inconsistent ad-hoc helpers spread across projects. Trogon.Result unifies those operations behind a single, well-typed API so that transforming, inspecting, and composing results is concise and consistent across the codebase.**
+
+**Trogon.Result is useful for any Elixir developer who writes functions returning `{:ok, _}` / `{:error, _}` tuples and wants richer combinators for composing them — especially in codebases with heavy pipeline-style code or where tapping into results for logging and metrics matters.**
 
 ## Documentation
 


### PR DESCRIPTION
- Most project READMEs were stubs with just a title and an API reference link, making it hard for newcomers to understand what each package does without reading the source
- Following the Diataxis framework, each README now has a 4-paragraph introduction covering identity, capabilities, problem solved, and target audience
- Updated: root, trogon_error, one_piece_graceful_shutdown, trogon_commanded, trogon_result, trogon_proto
- Skipped trogon_typeprovider and trogon_object_id which already had substantial introductions