### PR TITLE
fix(eventstore_dashboard): use original stream version in filtered events link

### DIFF
--- a/apps/eventstore_dashboard/lib/event_store_dashboard/components/events_table.ex
+++ b/apps/eventstore_dashboard/lib/event_store_dashboard/components/events_table.ex
@@ -72,7 +72,7 @@ defmodule EventStoreDashboard.Components.EventsTable do
           page={@page}
           ctx={@ctx}
           stream_uuid={row[:stream_uuid]}
-          event_number={row[:event_number]}
+          event_number={row[:stream_version]}
           stop_propagation
         />
       </:col>


### PR DESCRIPTION
- Linked-stream events have a different position in the filtered stream than in their original stream. The Stream Version column linked to the original stream UUID but used the filtered position, so the link could navigate to the wrong event. Aligns with the row-click handler, which already uses the original stream version.