### PR TITLE
fix(eventstore_dashboard): add .formatter.exs required by hex package build

### DIFF
--- a/apps/eventstore_dashboard/.formatter.exs
+++ b/apps/eventstore_dashboard/.formatter.exs
@@ -1,0 +1,5 @@
+[
+  line_length: 120,
+  import_deps: [:phoenix, :phoenix_live_view],
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs,heex}"]
+]

--- a/apps/eventstore_dashboard/lib/event_store_dashboard/components/subscriptions_table.ex
+++ b/apps/eventstore_dashboard/lib/event_store_dashboard/components/subscriptions_table.ex
@@ -237,9 +237,7 @@ defmodule EventStoreDashboard.Components.SubscriptionsTable do
   defp search_clause(nil, base_params, _index), do: {"", base_params}
 
   defp search_clause(term, base_params, index),
-    do:
-      {" WHERE s.subscription_name ILIKE $#{index} OR s.stream_uuid ILIKE $#{index}",
-       base_params ++ [term]}
+    do: {" WHERE s.subscription_name ILIKE $#{index} OR s.stream_uuid ILIKE $#{index}", base_params ++ [term]}
 
   defp sort_dir_sql(:asc), do: "ASC"
   defp sort_dir_sql(:desc), do: "DESC"

--- a/apps/eventstore_dashboard/mix.exs
+++ b/apps/eventstore_dashboard/mix.exs
@@ -102,8 +102,7 @@ defmodule EventStoreDashboard.MixProject do
     [
       main: "readme",
       homepage_url: @source_url,
-      source_url_pattern:
-        "#{@source_url}/blob/#{@app}@v#{@version}/apps/#{@app}/%{path}#L%{line}",
+      source_url_pattern: "#{@source_url}/blob/#{@app}@v#{@version}/apps/#{@app}/%{path}#L%{line}",
       skip_undefined_reference_warnings_on: ["CHANGELOG.md"],
       extras: [
         "README.md"


### PR DESCRIPTION
- Hex package build lists `.formatter.exs` in the included files but the file was missing, breaking the release publish step.