### PR TITLE
fix(eventstore_dashboard): keep modal usable when deserialization fails

### DIFF
--- a/apps/eventstore_dashboard/lib/event_store_dashboard/components/data_field.ex
+++ b/apps/eventstore_dashboard/lib/event_store_dashboard/components/data_field.ex
@@ -1,0 +1,36 @@
+defmodule EventStoreDashboard.Components.DataField do
+  @moduledoc false
+
+  use Phoenix.Component
+
+  attr(:label, :string, required: true)
+  attr(:value, :any, required: true)
+  attr(:inspect_opts, :list, required: true)
+
+  def row(%{value: {:deserialization_error, exception, raw}} = assigns) do
+    assigns = assign(assigns, exception: exception, raw: raw)
+
+    ~H"""
+    <tr>
+      <td>
+        <div class="d-flex align-items-center">
+          <span>{@label}</span>
+          <span class="badge badge-danger ml-2" title={Exception.message(@exception)}>
+            Failed
+          </span>
+        </div>
+      </td>
+      <td><pre>{inspect(@raw, @inspect_opts)}</pre></td>
+    </tr>
+    """
+  end
+
+  def row(assigns) do
+    ~H"""
+    <tr>
+      <td>{@label}</td>
+      <td><pre>{inspect(@value, @inspect_opts)}</pre></td>
+    </tr>
+    """
+  end
+end

--- a/apps/eventstore_dashboard/lib/event_store_dashboard/components/event_modal.ex
+++ b/apps/eventstore_dashboard/lib/event_store_dashboard/components/event_modal.ex
@@ -3,6 +3,7 @@ defmodule EventStoreDashboard.Components.EventModal do
 
   use Phoenix.LiveComponent
 
+  alias EventStoreDashboard.Components.DataField
   alias EventStoreDashboard.Params
   alias EventStoreDashboard.Repo
   alias EventStoreDashboard.Repo.Context
@@ -90,14 +91,8 @@ defmodule EventStoreDashboard.Components.EventModal do
               <td>Created at</td>
               <td><pre>{@event.created_at}</pre></td>
             </tr>
-            <tr>
-              <td>Data</td>
-              <td><pre>{inspect(@event.data, @inspect_opts)}</pre></td>
-            </tr>
-            <tr>
-              <td>Metadata</td>
-              <td><pre>{inspect(@event.metadata, @inspect_opts)}</pre></td>
-            </tr>
+            <DataField.row label="Data" value={@event.data} inspect_opts={@inspect_opts} />
+            <DataField.row label="Metadata" value={@event.metadata} inspect_opts={@inspect_opts} />
           </tbody>
         </table>
       </div>

--- a/apps/eventstore_dashboard/lib/event_store_dashboard/components/snapshot_modal.ex
+++ b/apps/eventstore_dashboard/lib/event_store_dashboard/components/snapshot_modal.ex
@@ -3,7 +3,7 @@ defmodule EventStoreDashboard.Components.SnapshotModal do
 
   use Phoenix.Component
 
-  alias EventStoreDashboard.Components.EventLink
+  alias EventStoreDashboard.Components.{DataField, EventLink}
   alias EventStoreDashboard.{Params, Repo}
   alias EventStoreDashboard.Repo.Context
   alias Phoenix.LiveDashboard.PageBuilder
@@ -61,14 +61,8 @@ defmodule EventStoreDashboard.Components.SnapshotModal do
               <td>Created at</td>
               <td><pre>{@snapshot.created_at}</pre></td>
             </tr>
-            <tr>
-              <td>Data</td>
-              <td><pre>{inspect(@snapshot.data, @inspect_opts)}</pre></td>
-            </tr>
-            <tr>
-              <td>Metadata</td>
-              <td><pre>{inspect(@snapshot.metadata, @inspect_opts)}</pre></td>
-            </tr>
+            <DataField.row label="Data" value={@snapshot.data} inspect_opts={@inspect_opts} />
+            <DataField.row label="Metadata" value={@snapshot.metadata} inspect_opts={@inspect_opts} />
           </tbody>
         </table>
       </div>

--- a/apps/eventstore_dashboard/lib/event_store_dashboard/repo.ex
+++ b/apps/eventstore_dashboard/lib/event_store_dashboard/repo.ex
@@ -336,7 +336,12 @@ defmodule EventStoreDashboard.Repo do
   end
 
   defp deserialize(nil, value, _opts), do: value
-  defp deserialize(serializer, value, opts), do: serializer.deserialize(value, opts)
+
+  defp deserialize(serializer, value, opts) do
+    serializer.deserialize(value, opts)
+  rescue
+    exception -> {:deserialization_error, exception, value}
+  end
 
   defp sort_dir_sql(:desc), do: "DESC"
   defp sort_dir_sql(_), do: "ASC"


### PR DESCRIPTION
- Serializer exceptions (e.g. unregistered type provider mapping) propagated through the LiveView and crashed the event/snapshot modal on every reconnect, leaving operators with no way to inspect the offending row.
- The dashboard is a diagnostic surface, so surfacing the raw payload with a clear failure indicator is more useful than failing closed.