### PR TITLE
chore(eventstore_dashboard): allow publishing docs via workflow dispatch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,7 @@ on:
         required: true
         type: choice
         options:
+          - eventstore_dashboard
           - trogon_commanded
           - trogon_error
           - trogon_proto


### PR DESCRIPTION
- Make the `eventstore_dashboard` package selectable in the hex-publish-docs workflow so its docs can be published from GitHub Actions like the other packages.