### PR TITLE
fix: support Elixir 1.20

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.19-otp-28
+elixir 1.20-otp-28
 erlang 28.3

--- a/apps/eventstore_dashboard/lib/event_store_dashboard/components/event_modal.ex
+++ b/apps/eventstore_dashboard/lib/event_store_dashboard/components/event_modal.ex
@@ -211,8 +211,6 @@ defmodule EventStoreDashboard.Components.EventModal do
     end
   end
 
-  defp fetch_id_counts(_node, nil, _event), do: {nil, nil}
-
   defp fetch_id_counts(node, %Context{} = ctx, event) do
     {count_for(node, ctx, :correlation_id, event.correlation_id),
      count_for(node, ctx, :causation_id, event.causation_id)}

--- a/apps/trogon_commanded/lib/trogon/commanded/value_object.ex
+++ b/apps/trogon_commanded/lib/trogon/commanded/value_object.ex
@@ -159,7 +159,7 @@ defmodule Trogon.Commanded.ValueObject do
 
   defp get_enforced_keys(env) do
     enforce_keys = Module.get_attribute(env.module, :enforce_keys) || []
-    enforce_keys ++ get_primary_key_name(env)
+    Enum.uniq(enforce_keys ++ get_primary_key_name(env))
   end
 
   defp get_primary_key_name(env) do

--- a/apps/trogon_ecto/lib/trogon/ecto/value_object.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/value_object.ex
@@ -207,7 +207,7 @@ defmodule Trogon.Ecto.ValueObject do
 
   defp get_enforced_keys(env) do
     enforce_keys = Module.get_attribute(env.module, :enforce_keys) || []
-    enforce_keys ++ get_primary_key_name(env)
+    Enum.uniq(enforce_keys ++ get_primary_key_name(env))
   end
 
   defp get_primary_key_name(env) do

--- a/apps/trogon_object_id/lib/trogon/object_id.ex
+++ b/apps/trogon_object_id/lib/trogon/object_id.ex
@@ -524,7 +524,7 @@ defmodule Trogon.ObjectId do
           {:ok, struct()} | {:error, atom()}
   def parse(module, prefix, prefix_len, string, validate_format) do
     case string do
-      <<^prefix::binary-size(prefix_len), suffix::binary>> when suffix != "" ->
+      <<^prefix::binary-size(^prefix_len), suffix::binary>> when suffix != "" ->
         validate_and_build(module, suffix, validate_format)
 
       _ ->

--- a/apps/trogon_proto/lib/trogon/proto/env.ex
+++ b/apps/trogon_proto/lib/trogon/proto/env.ex
@@ -409,9 +409,9 @@ defmodule Trogon.Proto.Env do
     )
   end
 
+  defp visibility_value(nil), do: Visibility.value(:VISIBILITY_UNSPECIFIED)
   defp visibility_value(atom) when is_atom(atom), do: Visibility.value(atom)
   defp visibility_value(int) when is_integer(int), do: int
-  defp visibility_value(nil), do: Visibility.value(:VISIBILITY_UNSPECIFIED)
 
   defp warn_unsupported_field(field_desc, field_type, is_repeated) do
     label_str =
@@ -437,13 +437,11 @@ defmodule Trogon.Proto.Env do
     delimiter && delimiter != ""
   end
 
-  defp valid_env_field?(field_type, is_repeated, env_var_option) when not is_nil(env_var_option) do
+  defp valid_env_field?(field_type, is_repeated, env_var_option) do
     scalar_supported = supported_env_type?(field_type)
     repeated_ok = not is_repeated || has_split_delimiter?(env_var_option)
     scalar_supported && repeated_ok
   end
-
-  defp valid_env_field?(_, _, _), do: false
 
   defp supported_env_type?(:TYPE_STRING), do: true
   defp supported_env_type?(:TYPE_INT32), do: true

--- a/apps/trogon_typeprovider/lib/trogon/type_provider.ex
+++ b/apps/trogon_typeprovider/lib/trogon/type_provider.ex
@@ -113,7 +113,7 @@ defmodule Trogon.TypeProvider do
   def __add_to_type_funcs__() do
     quote unquote: false do
       @spec to_type(struct()) :: {:ok, String.t()} | {:error, term()}
-      for {_, type, struct_mod} <- @type_mapping do
+      for {_, type, struct_mod} <- Enum.uniq_by(@type_mapping, &Trogon.TypeProvider.__struct_module__/1) do
         def to_type(%unquote(struct_mod){}) do
           {:ok, unquote(type)}
         end
@@ -128,6 +128,9 @@ defmodule Trogon.TypeProvider do
       end
     end
   end
+
+  @doc false
+  def __struct_module__({_, _, struct_mod}), do: struct_mod
 
   def __add_type_conversion_funcs__() do
     quote unquote: false do


### PR DESCRIPTION
- Elixir 1.20 ships a clause-type checker and stricter bitstring/match rules that reject constructs these packages previously emitted, so they no longer compile under 1.20 without these adjustments.
- Unblocks downstream consumers (e.g. the umbrella) from moving to Elixir 1.20.