### PR TITLE
fix(eventstore_dashboard): estimate unfiltered table totals via pg_class.reltuples

### DIFF
--- a/apps/eventstore_dashboard/lib/event_store_dashboard/components/streams_table.ex
+++ b/apps/eventstore_dashboard/lib/event_store_dashboard/components/streams_table.ex
@@ -7,6 +7,7 @@ defmodule EventStoreDashboard.Components.StreamsTable do
 
   alias EventStore.Sql.Statements
   alias EventStoreDashboard.Components.{EventLink, Pagination, TableParams}
+  alias EventStoreDashboard.Repo
   alias EventStoreDashboard.Repo.Context
   alias Phoenix.LiveDashboard.PageBuilder
   alias Phoenix.LiveView.Socket
@@ -80,7 +81,7 @@ defmodule EventStoreDashboard.Components.StreamsTable do
     search_term = url_params |> TableParams.parse_search() |> prefix_pattern()
     offset = (page_number - 1) * limit
 
-    with {:ok, total_entries} <- count_streams(node, ctx, search_term),
+    with {:ok, total_entries} <- Repo.count_streams(node, ctx, search_term),
          {:ok, rows} <-
            query_streams(node, ctx, sort_by, sort_dir, search_term, limit, offset) do
       total_pages = if total_entries == 0, do: 0, else: div(total_entries - 1, limit) + 1
@@ -92,15 +93,6 @@ defmodule EventStoreDashboard.Components.StreamsTable do
       }
     else
       _ -> %{entries: [], total_entries: 0, total_pages: 0}
-    end
-  end
-
-  defp count_streams(node, %Context{} = ctx, search_term) do
-    sql = IO.iodata_to_binary(Statements.count_streams(ctx.schema))
-
-    case :rpc.call(node, Postgrex, :query, [ctx.conn, sql, [search_term]]) do
-      {:ok, %Postgrex.Result{rows: [[count]]}} -> {:ok, count}
-      _ -> :error
     end
   end
 

--- a/apps/eventstore_dashboard/lib/event_store_dashboard/components/subscriptions_table.ex
+++ b/apps/eventstore_dashboard/lib/event_store_dashboard/components/subscriptions_table.ex
@@ -148,7 +148,7 @@ defmodule EventStoreDashboard.Components.SubscriptionsTable do
     search_term = url_params |> TableParams.parse_search() |> like_pattern()
     offset = (page_number - 1) * limit
 
-    with {:ok, total_entries} <- count_subscriptions(node, ctx, search_term),
+    with {:ok, total_entries} <- Repo.count_subscriptions(node, ctx, search_term),
          {:ok, rows} <-
            query_subscriptions(
              node,
@@ -168,16 +168,6 @@ defmodule EventStoreDashboard.Components.SubscriptionsTable do
       }
     else
       _ -> %{entries: [], total_entries: 0, total_pages: 0}
-    end
-  end
-
-  defp count_subscriptions(node, %Context{} = ctx, search_term) do
-    {where, params} = search_clause(search_term, [], 1)
-    sql = "SELECT COUNT(*) FROM #{ctx.schema}.subscriptions s#{where};"
-
-    case Repo.query(node, ctx.conn, sql, params) do
-      {:ok, [[count]]} -> {:ok, count}
-      _ -> :error
     end
   end
 

--- a/apps/eventstore_dashboard/lib/event_store_dashboard/repo.ex
+++ b/apps/eventstore_dashboard/lib/event_store_dashboard/repo.ex
@@ -227,11 +227,19 @@ defmodule EventStoreDashboard.Repo do
   the database CPU. `reltuples` is maintained by `ANALYZE`/autovacuum and is
   accurate enough for a monitoring view. A never-analyzed table reports `-1`,
   which is clamped to `0`. Returns `{:ok, non_neg_integer}` or `:error`.
+
+  The schema-qualified table name is interpolated into the `::regclass` literal
+  rather than passed as a parameter: `$1::regclass` makes PostgreSQL infer the
+  bind type as `oid`, and Postgrex then refuses to encode the textual name as an
+  integer oid. `schema` is trusted config and `table` is a fixed internal value,
+  so interpolation is safe here (matching the other queries in this module).
   """
   def estimate_count(node, %Context{} = ctx, table) when is_binary(table) do
-    sql = "SELECT GREATEST(reltuples, 0)::bigint FROM pg_class WHERE oid = $1::regclass"
+    sql =
+      "SELECT GREATEST(reltuples, 0)::bigint FROM pg_class " <>
+        "WHERE oid = '#{ctx.schema}.#{table}'::regclass"
 
-    case query(node, ctx.conn, sql, ["#{ctx.schema}.#{table}"]) do
+    case query(node, ctx.conn, sql, []) do
       {:ok, [[count]]} -> {:ok, count}
       _ -> :error
     end

--- a/apps/eventstore_dashboard/lib/event_store_dashboard/repo.ex
+++ b/apps/eventstore_dashboard/lib/event_store_dashboard/repo.ex
@@ -3,6 +3,7 @@ defmodule EventStoreDashboard.Repo do
 
   require Logger
 
+  alias EventStore.Sql.Statements
   alias EventStore.UUID
   alias EventStoreDashboard.{Event, Snapshot, Stream, Subscription}
   alias EventStoreDashboard.Repo.Context
@@ -215,6 +216,72 @@ defmodule EventStoreDashboard.Repo do
   end
 
   def string_to_uuid(_), do: :error
+
+  @doc """
+  Approximate row count for an entire table from PostgreSQL planner statistics
+  (`pg_class.reltuples`), avoiding a `COUNT(*)` sequential scan.
+
+  Used for unfiltered dashboard pagination totals. Event-store tables such as
+  `streams` and `events` are frequently very large and deliberately lightly
+  indexed for write throughput, so a full `COUNT(*)` reads every row and can peg
+  the database CPU. `reltuples` is maintained by `ANALYZE`/autovacuum and is
+  accurate enough for a monitoring view. A never-analyzed table reports `-1`,
+  which is clamped to `0`. Returns `{:ok, non_neg_integer}` or `:error`.
+  """
+  def estimate_count(node, %Context{} = ctx, table) when is_binary(table) do
+    sql = "SELECT GREATEST(reltuples, 0)::bigint FROM pg_class WHERE oid = $1::regclass"
+
+    case query(node, ctx.conn, sql, ["#{ctx.schema}.#{table}"]) do
+      {:ok, [[count]]} -> {:ok, count}
+      _ -> :error
+    end
+  end
+
+  @doc """
+  Total number of streams for the dashboard's streams table.
+
+  `"%"` is the match-all term used by the unfiltered view; it returns a fast
+  `estimate_count/3` rather than `COUNT(*)` over the entire streams table. A real
+  search term falls back to an exact filtered count. Returns `{:ok, non_neg_integer}`
+  or `:error`.
+  """
+  def count_streams(node, %Context{} = ctx, "%"), do: estimate_count(node, ctx, "streams")
+
+  def count_streams(node, %Context{} = ctx, search_term) do
+    sql = IO.iodata_to_binary(Statements.count_streams(ctx.schema))
+
+    case query(node, ctx.conn, sql, [search_term]) do
+      {:ok, [[count]]} -> {:ok, count}
+      _ -> :error
+    end
+  end
+
+  @doc """
+  Total number of subscriptions for the dashboard's subscriptions table.
+
+  With no search term, returns a fast `estimate_count/3`; a search term falls back
+  to an exact `ILIKE` filtered count. Returns `{:ok, non_neg_integer}` or `:error`.
+  """
+  def count_subscriptions(node, %Context{} = ctx, nil), do: estimate_count(node, ctx, "subscriptions")
+
+  def count_subscriptions(node, %Context{} = ctx, search_term) do
+    sql =
+      "SELECT COUNT(*) FROM #{ctx.schema}.subscriptions s " <>
+        "WHERE s.subscription_name ILIKE $1 OR s.stream_uuid ILIKE $1;"
+
+    case query(node, ctx.conn, sql, [search_term]) do
+      {:ok, [[count]]} -> {:ok, count}
+      _ -> :error
+    end
+  end
+
+  @doc """
+  Total number of snapshots for the dashboard's snapshots table.
+
+  With no search term, returns a fast `estimate_count/3`; a search term falls back
+  to an exact filtered count. Returns `{:ok, non_neg_integer}` or `:error`.
+  """
+  def count_snapshots(node, %Context{} = ctx, nil), do: estimate_count(node, ctx, "snapshots")
 
   def count_snapshots(node, %Context{} = ctx, search_term) do
     {where, params} = snapshot_search_clause(search_term, [], 1)


### PR DESCRIPTION
## Summary

The streams / subscriptions / snapshots tables compute their **pagination total** with `COUNT(*)` over the whole table. On a large event store the streams total is a multi-million-row sequential scan, and the LiveDashboard pages auto-refresh it across every connected session — enough to pin the event-store PostgreSQL CPU (observed 70–95% while otherwise idle). Event-store tables are also frequently lightly indexed for write throughput, so there's no index-only path.

This PR fixes the **unfiltered** totals by using PostgreSQL planner statistics instead of scanning:

```sql
SELECT GREATEST(reltuples, 0)::bigint FROM pg_class WHERE oid = $1::regclass
```

`reltuples` is maintained by `ANALYZE`/autovacuum and is accurate enough for a monitoring view (a never-analyzed table reports `-1`, clamped to `0`). **Filtered/search counts are unchanged** (they're scoped and user-initiated).

## Changes

- `Repo.estimate_count/3` — scan-free whole-table estimate via `pg_class.reltuples`
- `StreamsTable.count_streams` — estimate when the search term is `"%"` (match-all)
- `SubscriptionsTable.count_subscriptions` and `Repo.count_snapshots` — estimate when there is no search term

## Scope

- Resolves #413 (unfiltered whole-table totals).
- Does **not** address #414 (filtered/scoped counts on often-unindexed columns) — `reltuples` can't estimate a filtered count; that's left open for discussion.

## Verification

- `mix compile --warnings-as-errors` clean; `mix format --check-formatted` clean.
- Behaviour established empirically: killing the dashboard's `COUNT(*)`-refreshing LiveDashboard processes dropped a production event-store DB's load avg from ~19.9 to ~4.7.
