### PR TITLE
fix(trogon_object_id,trogon_commanded,trogon_error): default mix deps to Hex requirements outside the umbrella

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,6 @@ on:
 
 jobs:
   qa:
-    uses: straw-hat-team/github-actions-workflows/.github/workflows/elixir-quality-assurance.yml@b6b38e0383f168adbac8af563f2a29a52de0d141 # yordis/feat-mix-in-umbrella-deps, re-pin to master after straw-hat-team/github-actions-workflows#28 merges
+    uses: straw-hat-team/github-actions-workflows/.github/workflows/elixir-quality-assurance.yml@f93d234b888e3929141c5faed223e6071fe2c60e # v1.9.0
     with:
       mix-in-umbrella-deps: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,4 +10,6 @@ on:
 
 jobs:
   qa:
-    uses: straw-hat-team/github-actions-workflows/.github/workflows/elixir-quality-assurance.yml@0566a3861e8d30656cd902efd6208247df46bf60 # master
+    uses: straw-hat-team/github-actions-workflows/.github/workflows/elixir-quality-assurance.yml@b6b38e0383f168adbac8af563f2a29a52de0d141 # yordis/feat-mix-in-umbrella-deps, re-pin to master after straw-hat-team/github-actions-workflows#28 merges
+    with:
+      mix-in-umbrella-deps: true

--- a/apps/trogon_commanded/mix.exs
+++ b/apps/trogon_commanded/mix.exs
@@ -57,19 +57,22 @@ defmodule Trogon.Commanded.MixProject do
     ]
   end
 
+  # Hex consumers compile this file from deps/, so the Hex branch must be the
+  # default. Umbrella mode is opt-in via mise.toml locally and the
+  # mix-in-umbrella-deps input in CI.
   defp trogon_proto_dep do
-    if System.get_env("MIX_IN_UMBRELLA_DEPS") == "false" do
-      {:trogon_proto, "~> 0.4", optional: true}
-    else
+    if System.get_env("MIX_IN_UMBRELLA_DEPS") == "true" do
       {:trogon_proto, in_umbrella: true}
+    else
+      {:trogon_proto, "~> 0.4", optional: true}
     end
   end
 
   defp trogon_object_id_dep do
-    if System.get_env("MIX_IN_UMBRELLA_DEPS") == "false" do
-      {:trogon_object_id, "~> 0.1"}
-    else
+    if System.get_env("MIX_IN_UMBRELLA_DEPS") == "true" do
       {:trogon_object_id, in_umbrella: true}
+    else
+      {:trogon_object_id, "~> 0.1"}
     end
   end
 

--- a/apps/trogon_error/mix.exs
+++ b/apps/trogon_error/mix.exs
@@ -52,11 +52,14 @@ defmodule Trogon.Error.MixProject do
     ]
   end
 
+  # Hex consumers compile this file from deps/, so the Hex branch must be the
+  # default. Umbrella mode is opt-in via mise.toml locally and the
+  # mix-in-umbrella-deps input in CI.
   defp trogon_proto_dep do
-    if System.get_env("MIX_IN_UMBRELLA_DEPS") == "false" do
-      {:trogon_proto, "~> 0.8", optional: true}
+    if System.get_env("MIX_IN_UMBRELLA_DEPS") == "true" do
+      {:trogon_proto, in_umbrella: true}
     else
-      {:trogon_proto, in_umbrella: true, optional: true}
+      {:trogon_proto, "~> 0.8", optional: true}
     end
   end
 

--- a/apps/trogon_object_id/mix.exs
+++ b/apps/trogon_object_id/mix.exs
@@ -55,11 +55,14 @@ defmodule Trogon.ObjectId.MixProject do
     ]
   end
 
+  # Hex consumers compile this file from deps/, so the Hex branch must be the
+  # default. Umbrella mode is opt-in via mise.toml locally and the
+  # mix-in-umbrella-deps input in CI.
   defp trogon_proto_dep do
-    if System.get_env("MIX_IN_UMBRELLA_DEPS") == "false" do
-      {:trogon_proto, "~> 0.4", optional: true}
-    else
+    if System.get_env("MIX_IN_UMBRELLA_DEPS") == "true" do
       {:trogon_proto, in_umbrella: true}
+    else
+      {:trogon_proto, "~> 0.4", optional: true}
     end
   end
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[env]
+MIX_IN_UMBRELLA_DEPS = "true"


### PR DESCRIPTION
- Published packages ship their mix.exs, and consumers compile the `.app` file from it. With umbrella mode as the fallback branch, every Hex consumer resolved `trogon_proto` as a required `in_umbrella` dep while the publish-time metadata correctly marked it optional, so OTP required an application that was never fetched and apps crashed at boot with `could not find application file: trogon_proto.app` (trogon_object_id 0.1.1).
- Defaulting to Hex requirements makes that broken consumer state unrepresentable; umbrella mode is now an explicit opt-in for this repo only.
- Depends on straw-hat-team/github-actions-workflows#28; ci.yml is temporarily pinned to that PR head and should be re-pinned to master once it merges.