### PR TITLE
fix(ci): align release-please signoff with renamed bot account

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -52,5 +52,5 @@
   "prerelease": false,
   "pull-request-header": "An automated release has been created for you.",
   "separate-pull-requests": true,
-  "signoff": "Straw Hat Team Bot <61149376+sht-bot@users.noreply.github.com>"
+  "signoff": "SHT Bot <61149376+sht-bot@users.noreply.github.com>"
 }


### PR DESCRIPTION
- The bot account was renamed to `SHT Bot`, so release-please commits are authored under the new name while the configured signoff still used the old one; the DCO check requires the Signed-off-by line to match the commit author exactly, which is why every open release PR is failing DCO.