### PR TITLE
fix(ci): unblock Hex publishes broken by umbrella dep polarity flip

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,12 @@ on:
     types:
       - released
       - prereleased
+  workflow_dispatch:
+    inputs:
+      ref-name:
+        description: Release tag to publish, in the format "[package name]@v[version]"
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -18,7 +24,7 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           HEX_API_KEY: "${{ secrets.SECRETS_VAULT }}/HEX_API_KEY"
-      - uses: straw-hat-team/github-actions-workflows/elixir/umbrella-publish@0566a3861e8d30656cd902efd6208247df46bf60 # master
+      - uses: straw-hat-team/github-actions-workflows/elixir/umbrella-publish@5ab906d801d41b723636b498e57509e18db1856a # v1.9.1
         with:
           hex-api-key: ${{ env.HEX_API_KEY }}
-          ref-name: ${{ github.ref_name }}
+          ref-name: ${{ github.event_name == 'workflow_dispatch' && inputs.ref-name || github.ref_name }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           HEX_API_KEY: "${{ secrets.SECRETS_VAULT }}/HEX_API_KEY"
-      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@0566a3861e8d30656cd902efd6208247df46bf60 # master
+      - uses: straw-hat-team/github-actions-workflows/elixir/publish-docs@5ab906d801d41b723636b498e57509e18db1856a # v1.9.1
         with:
           hex-api-key: ${{ env.HEX_API_KEY }}
           package-name: ${{ inputs.package-name }}


### PR DESCRIPTION
- Publish runs failed at the setup step's root `mix deps.get` because umbrella mode is now opt-in and nothing set `MIX_IN_UMBRELLA_DEPS=true` there; v1.9.1 of the publish actions does so.
- Release-triggered runs snapshot cd.yml from the tagged commit, so the already-cut tags (trogon_object_id@v0.1.2, trogon_commanded@v1.0.2, trogon_error@v0.8.2) can never pick up this fix through re-runs; workflow_dispatch lets us re-fire those publishes from master.