### PR TITLE
feat(trogon_object_id): add Phoenix.Param, Phoenix.HTML.Safe, and JSON.Encoder protocols

### DIFF
--- a/apps/trogon_object_id/docs/references/protocols.md
+++ b/apps/trogon_object_id/docs/references/protocols.md
@@ -1,0 +1,86 @@
+# Protocols
+
+Every module that calls `use Trogon.ObjectId` or `use Trogon.UnionObjectId` has protocol
+implementations generated into it. The implementations live in your module, not in this
+library, so they do not appear in this documentation as modules of their own.
+
+## Emitted format
+
+Each protocol emits one of two forms: the *full* form, `#{prefix}#{separator}#{id}`, or the
+*bare* form, `id` with no prefix.
+
+| Protocol | Emits | Controlled by |
+| --- | --- | --- |
+| `String.Chars` | Full | Nothing, always full |
+| `Jason.Encoder` | Full or bare | `:json_format` |
+| `JSON.Encoder` | Full or bare | `:json_format` |
+| `c:Ecto.Type.dump/1` and `to_storage/1` | Full or bare | `:storage_format` |
+| `Phoenix.Param` | Full | Nothing, always full |
+| `Phoenix.HTML.Safe` | Full, HTML escaped | Nothing, always full |
+
+Given a type declared with `json_format: :drop_prefix`:
+
+```elixir
+defmodule MyApp.UserId do
+  use Trogon.ObjectId, object_type: "user", json_format: :drop_prefix
+end
+
+user_id = MyApp.UserId.new!("abc-123")
+
+to_string(user_id)                 #=> "user_abc-123"
+JSON.encode!(user_id)              #=> "\"abc-123\""
+Jason.encode!(user_id)             #=> "\"abc-123\""
+Phoenix.Param.to_param(user_id)    #=> "user_abc-123"
+```
+
+## Why `Phoenix.Param` ignores `:json_format`
+
+`Phoenix.Param.to_param/1` output has to survive a roundtrip back into your application, and
+both `parse/1` and `c:Ecto.Type.cast/1` accept only the full form. A param emitted in the bare
+form would fail to parse on the way back in, so `Phoenix.Param` always emits the full form
+regardless of how the type is configured for JSON.
+
+This matters even if you never render an object id into a URL yourself. `Phoenix.Param` sets
+`@fallback_to_any true`, and its `Any` implementation matches any struct carrying an `:id`
+key, which every object id does. Without a generated implementation, `~p"/users/#{user_id}"`
+would silently produce `/users/abc-123` rather than `/users/user_abc-123`, with no error
+raised at the point the wrong value was produced.
+
+## Optional dependencies
+
+Three of the protocols come from optional packages. Each implementation is wrapped in a
+`Code.ensure_loaded?/1` check that is evaluated when *your* module is compiled, not when this
+library is compiled.
+
+| Protocol | Requires |
+| --- | --- |
+| `Jason.Encoder` | `:jason` |
+| `JSON.Encoder` | Elixir 1.18 or later |
+| `Phoenix.Param` | `:phoenix` |
+| `Phoenix.HTML.Safe` | `:phoenix_html` |
+
+If you add one of these packages after your object id modules have already been compiled,
+recompile them so the implementation is generated:
+
+```console
+$ mix deps.compile --force my_app
+```
+
+`Jason.Encoder` and `JSON.Encoder` read the same `:json_format` option and are generated
+together, so a type encodes identically no matter which of the two a caller reaches for.
+
+## Union types
+
+A `Trogon.UnionObjectId` delegates every protocol to the member it wraps, so the member's own
+`:json_format` decides the encoded form:
+
+```elixir
+defmodule MyApp.PrincipalId do
+  use Trogon.UnionObjectId, types: [MyApp.UserId, MyApp.SystemId]
+end
+
+principal = MyApp.PrincipalId.new(MyApp.UserId.new!("abc-123"))
+
+JSON.encode!(principal)           #=> "\"abc-123\""
+Phoenix.Param.to_param(principal) #=> "user_abc-123"
+```

--- a/apps/trogon_object_id/lib/trogon/object_id.ex
+++ b/apps/trogon_object_id/lib/trogon/object_id.ex
@@ -72,13 +72,13 @@ defmodule Trogon.ObjectId do
 
   ## Protocols
 
-  Each generated ObjectId implements the following protocols:
+  Each generated ObjectId implements `String.Chars`, `Ecto.Type`, `Jason.Encoder`,
+  `JSON.Encoder`, `Phoenix.Param` and `Phoenix.HTML.Safe`. The emitted form differs per
+  protocol: `json_format` governs the two JSON encoders, `storage_format` governs Ecto, and
+  the rest always emit the full prefixed form.
 
-  - `String.Chars` - always the full prefixed form, regardless of any format option.
-  - `Jason.Encoder` and `JSON.Encoder` - follow `json_format`.
-  - `Ecto.Type` dump and `to_storage/1` - follow `storage_format`.
-  - `Phoenix.Param` and `Phoenix.HTML.Safe` - always the full prefixed form. `Phoenix.Param.to_param/1`
-    must roundtrip through `parse/1`, so it never respects `json_format` or `storage_format`.
+  See [Protocols](docs/references/protocols.md) for the full table, the optional dependencies
+  each one needs, and why `Phoenix.Param` ignores `json_format`.
   """
 
   alias Trogon.ObjectId.ProtoExtension
@@ -595,13 +595,27 @@ defmodule Trogon.ObjectId do
 
   defp __generated_protocols__(prefix, json_format) do
     quote location: :keep do
+      unquote(__generated_string_chars_impl__(prefix))
+      unquote(__generated_jason_impl__(prefix, json_format))
+      unquote(__generated_json_impl__(prefix, json_format))
+      unquote(__generated_phoenix_param_impl__())
+      unquote(__generated_phoenix_html_safe_impl__())
+    end
+  end
+
+  defp __generated_string_chars_impl__(prefix) do
+    quote location: :keep do
       defimpl String.Chars do
         @moduledoc false
         def to_string(%@for{id: id}) when is_binary(id) do
           "#{unquote(prefix)}#{id}"
         end
       end
+    end
+  end
 
+  defp __generated_jason_impl__(prefix, json_format) do
+    quote location: :keep do
       if Code.ensure_loaded?(Jason.Encoder) do
         defimpl Jason.Encoder do
           @moduledoc false
@@ -611,22 +625,36 @@ defmodule Trogon.ObjectId do
           end
         end
       end
+    end
+  end
 
-      defimpl JSON.Encoder do
-        @moduledoc false
-        def encode(%@for{id: id}, encoder) when is_binary(id) do
-          value = Trogon.ObjectId.format(unquote(json_format), unquote(prefix), id)
-          encoder.(value, encoder)
+  defp __generated_json_impl__(prefix, json_format) do
+    quote location: :keep do
+      if Code.ensure_loaded?(JSON.Encoder) do
+        defimpl JSON.Encoder do
+          @moduledoc false
+          def encode(%@for{id: id}, encoder) when is_binary(id) do
+            value = Trogon.ObjectId.format(unquote(json_format), unquote(prefix), id)
+            encoder.(value, encoder)
+          end
         end
       end
+    end
+  end
 
+  defp __generated_phoenix_param_impl__ do
+    quote location: :keep do
       if Code.ensure_loaded?(Phoenix.Param) do
         defimpl Phoenix.Param do
           @moduledoc false
           def to_param(%@for{id: id} = object_id) when is_binary(id), do: Kernel.to_string(object_id)
         end
       end
+    end
+  end
 
+  defp __generated_phoenix_html_safe_impl__ do
+    quote location: :keep do
       if Code.ensure_loaded?(Phoenix.HTML.Safe) do
         defimpl Phoenix.HTML.Safe do
           @moduledoc false

--- a/apps/trogon_object_id/lib/trogon/object_id.ex
+++ b/apps/trogon_object_id/lib/trogon/object_id.ex
@@ -69,6 +69,16 @@ defmodule Trogon.ObjectId do
       @primary_key {:id, MyApp.UserId, autogenerate: true}
       schema "users" do
       end
+
+  ## Protocols
+
+  Each generated ObjectId implements the following protocols:
+
+  - `String.Chars` - always the full prefixed form, regardless of any format option.
+  - `Jason.Encoder` and `JSON.Encoder` - follow `json_format`.
+  - `Ecto.Type` dump and `to_storage/1` - follow `storage_format`.
+  - `Phoenix.Param` and `Phoenix.HTML.Safe` - always the full prefixed form. `Phoenix.Param.to_param/1`
+    must roundtrip through `parse/1`, so it never respects `json_format` or `storage_format`.
   """
 
   alias Trogon.ObjectId.ProtoExtension
@@ -598,6 +608,30 @@ defmodule Trogon.ObjectId do
           def encode(%@for{id: id}, opts) when is_binary(id) do
             value = Trogon.ObjectId.format(unquote(json_format), unquote(prefix), id)
             Jason.Encode.string(value, opts)
+          end
+        end
+      end
+
+      defimpl JSON.Encoder do
+        @moduledoc false
+        def encode(%@for{id: id}, encoder) when is_binary(id) do
+          value = Trogon.ObjectId.format(unquote(json_format), unquote(prefix), id)
+          encoder.(value, encoder)
+        end
+      end
+
+      if Code.ensure_loaded?(Phoenix.Param) do
+        defimpl Phoenix.Param do
+          @moduledoc false
+          def to_param(%@for{id: id} = object_id) when is_binary(id), do: Kernel.to_string(object_id)
+        end
+      end
+
+      if Code.ensure_loaded?(Phoenix.HTML.Safe) do
+        defimpl Phoenix.HTML.Safe do
+          @moduledoc false
+          def to_iodata(%@for{id: id} = object_id) when is_binary(id) do
+            Phoenix.HTML.Safe.to_iodata(Kernel.to_string(object_id))
           end
         end
       end

--- a/apps/trogon_object_id/lib/trogon/union_object_id.ex
+++ b/apps/trogon_object_id/lib/trogon/union_object_id.ex
@@ -323,11 +323,25 @@ defmodule Trogon.UnionObjectId do
 
   defp __generated_protocols__() do
     quote location: :keep do
+      unquote(__generated_string_chars_impl__())
+      unquote(__generated_jason_impl__())
+      unquote(__generated_json_impl__())
+      unquote(__generated_phoenix_param_impl__())
+      unquote(__generated_phoenix_html_safe_impl__())
+    end
+  end
+
+  defp __generated_string_chars_impl__() do
+    quote location: :keep do
       defimpl String.Chars do
         @moduledoc false
         def to_string(%@for{id: id}), do: Kernel.to_string(id)
       end
+    end
+  end
 
+  defp __generated_jason_impl__() do
+    quote location: :keep do
       if Code.ensure_loaded?(Jason.Encoder) do
         defimpl Jason.Encoder do
           @moduledoc false
@@ -336,19 +350,33 @@ defmodule Trogon.UnionObjectId do
           end
         end
       end
+    end
+  end
 
-      defimpl JSON.Encoder do
-        @moduledoc false
-        def encode(%@for{id: id}, encoder), do: JSON.Encoder.encode(id, encoder)
+  defp __generated_json_impl__() do
+    quote location: :keep do
+      if Code.ensure_loaded?(JSON.Encoder) do
+        defimpl JSON.Encoder do
+          @moduledoc false
+          def encode(%@for{id: id}, encoder), do: JSON.Encoder.encode(id, encoder)
+        end
       end
+    end
+  end
 
+  defp __generated_phoenix_param_impl__() do
+    quote location: :keep do
       if Code.ensure_loaded?(Phoenix.Param) do
         defimpl Phoenix.Param do
           @moduledoc false
           def to_param(%@for{id: id}), do: Kernel.to_string(id)
         end
       end
+    end
+  end
 
+  defp __generated_phoenix_html_safe_impl__() do
+    quote location: :keep do
       if Code.ensure_loaded?(Phoenix.HTML.Safe) do
         defimpl Phoenix.HTML.Safe do
           @moduledoc false

--- a/apps/trogon_object_id/lib/trogon/union_object_id.ex
+++ b/apps/trogon_object_id/lib/trogon/union_object_id.ex
@@ -336,6 +336,25 @@ defmodule Trogon.UnionObjectId do
           end
         end
       end
+
+      defimpl JSON.Encoder do
+        @moduledoc false
+        def encode(%@for{id: id}, encoder), do: JSON.Encoder.encode(id, encoder)
+      end
+
+      if Code.ensure_loaded?(Phoenix.Param) do
+        defimpl Phoenix.Param do
+          @moduledoc false
+          def to_param(%@for{id: id}), do: Kernel.to_string(id)
+        end
+      end
+
+      if Code.ensure_loaded?(Phoenix.HTML.Safe) do
+        defimpl Phoenix.HTML.Safe do
+          @moduledoc false
+          def to_iodata(%@for{id: id}), do: Phoenix.HTML.Safe.to_iodata(Kernel.to_string(id))
+        end
+      end
     end
   end
 

--- a/apps/trogon_object_id/mix.exs
+++ b/apps/trogon_object_id/mix.exs
@@ -42,6 +42,8 @@ defmodule Trogon.ObjectId.MixProject do
     [
       {:uniq, "~> 0.1"},
       {:jason, "~> 1.2", optional: true},
+      {:phoenix, "~> 1.7", optional: true},
+      {:phoenix_html, "~> 3.3 or ~> 4.0", optional: true},
       {:ecto, "~> 3.6"},
       {:nimble_options, "~> 1.0"},
       {:protobuf, "~> 0.16", optional: true},

--- a/apps/trogon_object_id/mix.exs
+++ b/apps/trogon_object_id/mix.exs
@@ -102,6 +102,7 @@ defmodule Trogon.ObjectId.MixProject do
       name: @app,
       files: [
         ".formatter.exs",
+        "docs",
         "lib",
         "mix.exs",
         "README*",
@@ -123,6 +124,7 @@ defmodule Trogon.ObjectId.MixProject do
       skip_undefined_reference_warnings_on: ["CHANGELOG.md"],
       extras: [
         "README.md",
+        "docs/references/protocols.md",
         "CHANGELOG.md"
       ],
       groups_for_extras: [

--- a/apps/trogon_object_id/test/support/test_support.ex
+++ b/apps/trogon_object_id/test/support/test_support.ex
@@ -82,6 +82,11 @@ defmodule Trogon.ObjectId.TestSupport do
     use Trogon.UnionObjectId, types: [TenantId, SystemId]
   end
 
+  defmodule MixedJsonFormatUnionId do
+    @moduledoc false
+    use Trogon.UnionObjectId, types: [TenantId, JsonDropPrefixId]
+  end
+
   defmodule PrincipalId do
     @moduledoc false
     use Trogon.UnionObjectId, types: [TenantId, SystemId, ServiceId]

--- a/apps/trogon_object_id/test/trogon/object_id_test.exs
+++ b/apps/trogon_object_id/test/trogon/object_id_test.exs
@@ -489,6 +489,73 @@ defmodule Trogon.ObjectIdTest do
     end
   end
 
+  describe "JSON.Encoder.encode/1" do
+    test "encodes with json_format: :full (default), matching Jason" do
+      typeid = TestSupport.UserId.new!(@test_uuid)
+
+      assert JSON.encode!(typeid) == ~s("user_#{@test_uuid}")
+      assert JSON.encode!(typeid) == Jason.encode!(typeid)
+    end
+
+    test "encodes with json_format: :drop_prefix, matching Jason" do
+      typeid = TestSupport.JsonDropPrefixId.new!(@test_uuid)
+
+      assert JSON.encode!(typeid) == ~s("#{@test_uuid}")
+      assert JSON.encode!(typeid) == Jason.encode!(typeid)
+    end
+
+    test "encodes within a map" do
+      typeid = TestSupport.UserId.new!(@test_uuid)
+      map = %{id: typeid, name: "test"}
+
+      assert JSON.encode!(map) == ~s({"id":"user_#{@test_uuid}","name":"test"})
+    end
+
+    test "raises FunctionClauseError for struct with nil id" do
+      assert_raise FunctionClauseError, fn ->
+        JSON.encode!(%TestSupport.UserId{id: nil})
+      end
+    end
+  end
+
+  describe "Phoenix.Param.to_param/1" do
+    test "returns the fully prefixed string" do
+      typeid = TestSupport.UserId.new!(@test_uuid)
+
+      assert Phoenix.Param.to_param(typeid) == "user_#{@test_uuid}"
+    end
+
+    test "returns the fully prefixed string for json_format: :drop_prefix" do
+      typeid = TestSupport.JsonDropPrefixId.new!(@test_uuid)
+
+      assert Phoenix.Param.to_param(typeid) == "jsondrop_#{@test_uuid}"
+    end
+
+    test "roundtrips through parse/1" do
+      typeid = TestSupport.JsonDropPrefixId.new!(@test_uuid)
+
+      param = Phoenix.Param.to_param(typeid)
+
+      assert {:ok, ^typeid} = TestSupport.JsonDropPrefixId.parse(param)
+    end
+  end
+
+  describe "Phoenix.HTML.Safe.to_iodata/1" do
+    test "returns the prefixed string" do
+      typeid = TestSupport.UserId.new!(@test_uuid)
+
+      assert Phoenix.HTML.Safe.to_iodata(typeid) |> IO.iodata_to_binary() == "user_#{@test_uuid}"
+    end
+
+    test "HTML-escapes the value" do
+      typeid = TestSupport.UserId.new!(~s(<script>"))
+
+      escaped = Phoenix.HTML.Safe.to_iodata(typeid) |> IO.iodata_to_binary()
+
+      assert escaped == "user_&lt;script&gt;&quot;"
+    end
+  end
+
   describe "format validation: :uuid" do
     @valid_uuid "550e8400-e29b-41d4-a716-446655440000"
 

--- a/apps/trogon_object_id/test/trogon/union_object_id_test.exs
+++ b/apps/trogon_object_id/test/trogon/union_object_id_test.exs
@@ -410,6 +410,58 @@ defmodule Trogon.UnionObjectIdTest do
     end
   end
 
+  describe "JSON.Encoder protocol" do
+    test "honors the member type's json_format: :full" do
+      tenant_id = TestSupport.TenantId.new!(@tenant_id_value)
+      union = TestSupport.MixedJsonFormatUnionId.new(tenant_id)
+
+      assert JSON.encode!(union) == ~s("tenant_#{@tenant_id_value}")
+      assert JSON.encode!(union) == Jason.encode!(union)
+    end
+
+    test "honors the member type's json_format: :drop_prefix" do
+      json_drop_id = TestSupport.JsonDropPrefixId.new!(@tenant_id_value)
+      union = TestSupport.MixedJsonFormatUnionId.new(json_drop_id)
+
+      assert JSON.encode!(union) == ~s("#{@tenant_id_value}")
+      assert JSON.encode!(union) == Jason.encode!(union)
+    end
+  end
+
+  describe "Phoenix.Param.to_param/1" do
+    test "returns the member's prefixed string" do
+      tenant_id = TestSupport.TenantId.new!(@tenant_id_value)
+      union = TestSupport.ContextId.new(tenant_id)
+
+      assert Phoenix.Param.to_param(union) == "tenant_#{@tenant_id_value}"
+    end
+
+    test "returns the member's prefixed string regardless of json_format" do
+      json_drop_id = TestSupport.JsonDropPrefixId.new!(@tenant_id_value)
+      union = TestSupport.MixedJsonFormatUnionId.new(json_drop_id)
+
+      assert Phoenix.Param.to_param(union) == "jsondrop_#{@tenant_id_value}"
+    end
+  end
+
+  describe "Phoenix.HTML.Safe.to_iodata/1" do
+    test "returns the member's prefixed string" do
+      tenant_id = TestSupport.TenantId.new!(@tenant_id_value)
+      union = TestSupport.ContextId.new(tenant_id)
+
+      assert union |> Phoenix.HTML.Safe.to_iodata() |> IO.iodata_to_binary() ==
+               "tenant_#{@tenant_id_value}"
+    end
+
+    test "HTML-escapes the member's value" do
+      tenant_id = TestSupport.TenantId.new!(~s(<script>"))
+      union = TestSupport.ContextId.new(tenant_id)
+
+      assert union |> Phoenix.HTML.Safe.to_iodata() |> IO.iodata_to_binary() ==
+               "tenant_&lt;script&gt;&quot;"
+    end
+  end
+
   describe "parse/1 with validated inner types" do
     test "rejects invalid value for a validated inner type" do
       assert {:error, _} = TestSupport.ValidatedUnionId.parse("uuid_not-a-uuid")


### PR DESCRIPTION
- `Phoenix.Param` has `@fallback_to_any true`, and its `Any` implementation matches any struct with an `:id` key. Object ids therefore rendered into URLs as the bare id with no prefix, which then failed to parse on the way back in. This was silent, not a crash.
- Elixir 1.18 ships a native `JSON` module, so consumers reaching for it instead of Jason got a `Protocol.UndefinedError`. Both encoders now read the same `json_format` option, so they cannot drift apart.
- `Phoenix.HTML.Safe` was missing, so rendering an object id in a template raised at render time.
- `Phoenix.Param` and `Phoenix.HTML.Safe` deliberately ignore `json_format` and always emit the fully prefixed form, because `to_param/1` output has to survive a roundtrip through `parse/1`, and `cast/1` only accepts the prefixed form.