### PR TITLE
feat(trogon_ecto): add enum type

### DIFF
--- a/apps/trogon_ecto/lib/trogon/ecto/enum.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/enum.ex
@@ -58,18 +58,6 @@ defmodule Trogon.Ecto.Enum do
         end
       end
 
-    dump_functions_ast =
-      for value <- values do
-        value_string = Atom.to_string(value)
-
-        quote do
-          @impl Ecto.Type
-          def dump(%__MODULE__{value: unquote(value)}) do
-            {:ok, unquote(value_string)}
-          end
-        end
-      end
-
     cast_as_function_ast =
       for value <- values do
         value_string = Atom.to_string(value)
@@ -166,8 +154,9 @@ defmodule Trogon.Ecto.Enum do
       @impl Ecto.Type
       def load(_), do: :error
 
-      unquote_splicing(dump_functions_ast)
       @impl Ecto.Type
+      @spec dump(any()) :: {:ok, String.t()} | :error
+      def dump(%__MODULE__{value: value}) when value in unquote(values), do: {:ok, Atom.to_string(value)}
       def dump(_), do: :error
 
       @impl Ecto.Type

--- a/apps/trogon_ecto/lib/trogon/ecto/enum.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/enum.ex
@@ -1,0 +1,200 @@
+defmodule Trogon.Ecto.Enum do
+  @moduledoc """
+  Defines an Enum type module.
+  """
+
+  @doc """
+  Converts the module into a struct with an `:value` enum field.
+
+  ## Using
+
+  - `Ecto.Schema`
+  - `Ecto.Type`
+
+  ## Usage
+
+      defmodule BankAccountType do
+        use Trogon.Ecto.Enum, values: [:business, :personal]
+      end
+
+      {:ok, type} = BankAccountType.new(:business)
+
+  You can use it in your `Ecto.Schema` like this:
+
+      defmodule BankAccount do
+        use Ecto.Schema
+
+        embedded_schema do
+          field :type, BankAccountType
+        end
+      end
+
+  ## JSON Encoding
+
+  When `Jason` or the native `JSON` module is available, the generated
+  module implements `Jason.Encoder` and `JSON.Encoder` respectively,
+  encoding the value object as the string form of its `:value`.
+  """
+  @spec __using__(opts :: Keyword.t()) :: Macro.t()
+  defmacro __using__(opts) do
+    values = Keyword.fetch!(opts, :values)
+
+    type_ast = Enum.reduce(values, &{:|, [], [&1, &2]})
+
+    value_functions_ast =
+      for value <- values do
+        quote do
+          def unquote(value)(), do: %__MODULE__{value: unquote(value)}
+        end
+      end
+
+    load_functions_ast =
+      for value <- values do
+        quote do
+          @impl Ecto.Type
+          def load(unquote(Atom.to_string(value))) do
+            {:ok, %__MODULE__{value: unquote(value)}}
+          end
+        end
+      end
+
+    dump_functions_ast =
+      for value <- values do
+        value_string = Atom.to_string(value)
+
+        quote do
+          @impl Ecto.Type
+          def dump(%__MODULE__{value: unquote(value)}) do
+            {:ok, unquote(value_string)}
+          end
+        end
+      end
+
+    cast_as_function_ast =
+      for value <- values do
+        value_string = Atom.to_string(value)
+
+        quote do
+          @impl Ecto.Type
+          def cast(unquote(value_string)) do
+            {:ok, %__MODULE__{value: unquote(value)}}
+          end
+        end
+      end
+
+    quote generated: true do
+      alias Trogon.Ecto.ValueObject
+      alias Ecto.Changeset
+
+      use Ecto.Schema
+      use Ecto.Type
+
+      @primary_key false
+      @enforce_keys [:value]
+      embedded_schema do
+        field :value, Ecto.Enum, values: unquote(values)
+      end
+
+      @type value :: unquote(type_ast)
+      @type t :: %__MODULE__{value: value()}
+
+      @doc """
+      Creates a `t:t/0`.
+      """
+      @spec new(attrs :: %{required(:value) => value()}) :: {:ok, %__MODULE__{}} | {:error, Ecto.Changeset.t()}
+      def new(attrs) when is_map(attrs) do
+        ValueObject.new(__MODULE__, attrs)
+      end
+
+      @spec new(value :: value()) :: {:ok, %__MODULE__{}} | {:error, Ecto.Changeset.t()}
+      def new(value) do
+        ValueObject.new(__MODULE__, %{value: value})
+      end
+
+      @doc """
+      Creates a `t:t/0`.
+      """
+      @spec new!(attrs :: %{required(:value) => value()}) :: %__MODULE__{}
+      def new!(attrs) when is_map(attrs) do
+        ValueObject.new!(__MODULE__, attrs)
+      end
+
+      @spec new!(value :: value()) :: %__MODULE__{}
+      def new!(value) do
+        ValueObject.new!(__MODULE__, %{value: value})
+      end
+
+      @doc """
+      Returns an `t:Ecto.Changeset.t/0` for a given `t:t/0` value object.
+      """
+      @spec changeset(message :: %__MODULE__{}, attrs :: %{required(:value) => value()}) :: Ecto.Changeset.t()
+      def changeset(message, attrs) do
+        message
+        |> Changeset.cast(attrs, [:value])
+        |> Changeset.validate_required([:value])
+      end
+
+      @spec values() :: [unquote(type_ast)]
+      def values, do: unquote(values)
+
+      unquote_splicing(value_functions_ast)
+
+      @impl Ecto.Type
+      def type, do: :string
+
+      @impl Ecto.Type
+      def cast(value) when is_struct(value, __MODULE__) do
+        {:ok, value}
+      end
+
+      @impl Ecto.Type
+      def cast(%{value: value}) do
+        cast(value)
+      end
+
+      unquote_splicing(cast_as_function_ast)
+
+      @impl Ecto.Type
+      def cast(value) when value in unquote(values) do
+        {:ok, %__MODULE__{value: value}}
+      end
+
+      @impl Ecto.Type
+      def cast(_), do: :error
+
+      unquote_splicing(load_functions_ast)
+      @impl Ecto.Type
+      def load(_), do: :error
+
+      unquote_splicing(dump_functions_ast)
+      @impl Ecto.Type
+      def dump(_), do: :error
+
+      @impl Ecto.Type
+      def equal?(%__MODULE__{value: value1}, %__MODULE__{value: value1}) do
+        true
+      end
+
+      @impl Ecto.Type
+      def equal?(_term1, _term2), do: false
+
+      if Code.ensure_loaded?(Jason.Encoder) do
+        defimpl Jason.Encoder do
+          @moduledoc false
+          def encode(%@for{value: value}, opts) do
+            Jason.Encode.string(Atom.to_string(value), opts)
+          end
+        end
+      end
+
+      if Code.ensure_loaded?(JSON.Encoder) do
+        defimpl JSON.Encoder do
+          @moduledoc false
+          def encode(%@for{value: value}, encoder) do
+            encoder.(Atom.to_string(value), encoder)
+          end
+        end
+      end
+    end
+  end
+end

--- a/apps/trogon_ecto/lib/trogon/ecto/enum.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/enum.ex
@@ -29,11 +29,15 @@ defmodule Trogon.Ecto.Enum do
         end
       end
 
-  ## JSON Encoding
+  ## Protocols
 
-  When `Jason` or the native `JSON` module is available, the generated
-  module implements `Jason.Encoder` and `JSON.Encoder` respectively,
-  encoding the value object as the string form of its `:value`.
+  The generated module always implements `String.Chars`, rendering as the
+  string form of its `:value`, the same form `dump/1` returns.
+
+  It also implements `Jason.Encoder`, `JSON.Encoder`, `Phoenix.Param` and
+  `Phoenix.HTML.Safe` when each is available, so an enum can be encoded,
+  used in a route helper, or rendered in a template without the consumer
+  taking on any of those dependencies.
   """
   @spec __using__(opts :: Keyword.t()) :: Macro.t()
   defmacro __using__(opts) do
@@ -167,20 +171,67 @@ defmodule Trogon.Ecto.Enum do
       @impl Ecto.Type
       def equal?(_term1, _term2), do: false
 
+      unquote(__generated_string_chars_impl__())
+      unquote(__generated_jason_impl__())
+      unquote(__generated_json_impl__())
+      unquote(__generated_phoenix_param_impl__())
+      unquote(__generated_phoenix_html_safe_impl__())
+    end
+  end
+
+  defp __generated_string_chars_impl__ do
+    quote location: :keep do
+      defimpl String.Chars do
+        @moduledoc false
+        def to_string(%@for{value: value}) when is_atom(value), do: Atom.to_string(value)
+      end
+    end
+  end
+
+  defp __generated_jason_impl__ do
+    quote location: :keep do
       if Code.ensure_loaded?(Jason.Encoder) do
         defimpl Jason.Encoder do
           @moduledoc false
-          def encode(%@for{value: value}, opts) do
+          def encode(%@for{value: value}, opts) when is_atom(value) do
             Jason.Encode.string(Atom.to_string(value), opts)
           end
         end
       end
+    end
+  end
 
+  defp __generated_json_impl__ do
+    quote location: :keep do
       if Code.ensure_loaded?(JSON.Encoder) do
         defimpl JSON.Encoder do
           @moduledoc false
-          def encode(%@for{value: value}, encoder) do
+          def encode(%@for{value: value}, encoder) when is_atom(value) do
             encoder.(Atom.to_string(value), encoder)
+          end
+        end
+      end
+    end
+  end
+
+  defp __generated_phoenix_param_impl__ do
+    quote location: :keep do
+      if Code.ensure_loaded?(Phoenix.Param) do
+        defimpl Phoenix.Param do
+          @moduledoc false
+          def to_param(%@for{value: value} = enum) when is_atom(value), do: Kernel.to_string(enum)
+        end
+      end
+    end
+  end
+
+  defp __generated_phoenix_html_safe_impl__ do
+    quote location: :keep do
+      if Code.ensure_loaded?(Phoenix.HTML.Safe) do
+        defimpl Phoenix.HTML.Safe do
+          @moduledoc false
+          def to_iodata(%@for{value: value} = enum) when is_atom(value) do
+            Phoenix.HTML.Safe.to_iodata(Kernel.to_string(enum))
           end
         end
       end

--- a/apps/trogon_ecto/lib/trogon/ecto/enum.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/enum.ex
@@ -94,6 +94,10 @@ defmodule Trogon.Ecto.Enum do
       Creates a `t:t/0`.
       """
       @spec new(attrs :: %{required(:value) => value()}) :: {:ok, %__MODULE__{}} | {:error, Ecto.Changeset.t()}
+      def new(%__MODULE__{} = value) do
+        ValueObject.new(__MODULE__, Map.from_struct(value))
+      end
+
       def new(attrs) when is_map(attrs) do
         ValueObject.new(__MODULE__, attrs)
       end
@@ -107,6 +111,10 @@ defmodule Trogon.Ecto.Enum do
       Creates a `t:t/0`.
       """
       @spec new!(attrs :: %{required(:value) => value()}) :: %__MODULE__{}
+      def new!(%__MODULE__{} = value) do
+        ValueObject.new!(__MODULE__, Map.from_struct(value))
+      end
+
       def new!(attrs) when is_map(attrs) do
         ValueObject.new!(__MODULE__, attrs)
       end
@@ -135,8 +143,8 @@ defmodule Trogon.Ecto.Enum do
       def type, do: :string
 
       @impl Ecto.Type
-      def cast(value) when is_struct(value, __MODULE__) do
-        {:ok, value}
+      def cast(%__MODULE__{value: value} = enum) when value in unquote(values) do
+        {:ok, enum}
       end
 
       @impl Ecto.Type

--- a/apps/trogon_ecto/lib/trogon/ecto/enum.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/enum.ex
@@ -43,38 +43,24 @@ defmodule Trogon.Ecto.Enum do
   defmacro __using__(opts) do
     values = Keyword.fetch!(opts, :values)
 
+    quote generated: true do
+      unquote(__generated_schema__(values))
+      unquote(__generated_constructors__())
+      unquote(__generated_changeset__())
+      unquote(__generated_values__(values))
+      unquote(__generated_ecto_type__())
+      unquote(__generated_ecto_cast__(values))
+      unquote(__generated_ecto_load__(values))
+      unquote(__generated_ecto_dump__(values))
+      unquote(__generated_ecto_comparison__())
+      unquote(__generated_protocols__())
+    end
+  end
+
+  defp __generated_schema__(values) do
     type_ast = Enum.reduce(values, &{:|, [], [&1, &2]})
 
-    value_functions_ast =
-      for value <- values do
-        quote do
-          def unquote(value)(), do: %__MODULE__{value: unquote(value)}
-        end
-      end
-
-    load_functions_ast =
-      for value <- values do
-        quote do
-          @impl Ecto.Type
-          def load(unquote(Atom.to_string(value))) do
-            {:ok, %__MODULE__{value: unquote(value)}}
-          end
-        end
-      end
-
-    cast_as_function_ast =
-      for value <- values do
-        value_string = Atom.to_string(value)
-
-        quote do
-          @impl Ecto.Type
-          def cast(unquote(value_string)) do
-            {:ok, %__MODULE__{value: unquote(value)}}
-          end
-        end
-      end
-
-    quote generated: true do
+    quote generated: true, location: :keep do
       alias Trogon.Ecto.ValueObject
       alias Ecto.Changeset
 
@@ -89,41 +75,33 @@ defmodule Trogon.Ecto.Enum do
 
       @type value :: unquote(type_ast)
       @type t :: %__MODULE__{value: value()}
+    end
+  end
 
+  defp __generated_constructors__ do
+    quote generated: true, location: :keep do
       @doc """
       Creates a `t:t/0`.
       """
       @spec new(attrs :: %{required(:value) => value()}) :: {:ok, %__MODULE__{}} | {:error, Ecto.Changeset.t()}
-      def new(%__MODULE__{} = value) do
-        ValueObject.new(__MODULE__, Map.from_struct(value))
-      end
-
-      def new(attrs) when is_map(attrs) do
-        ValueObject.new(__MODULE__, attrs)
-      end
-
       @spec new(value :: value()) :: {:ok, %__MODULE__{}} | {:error, Ecto.Changeset.t()}
-      def new(value) do
-        ValueObject.new(__MODULE__, %{value: value})
-      end
+      def new(%__MODULE__{} = value), do: ValueObject.new(__MODULE__, Map.from_struct(value))
+      def new(attrs) when is_map(attrs), do: ValueObject.new(__MODULE__, attrs)
+      def new(value), do: ValueObject.new(__MODULE__, %{value: value})
 
       @doc """
       Creates a `t:t/0`.
       """
       @spec new!(attrs :: %{required(:value) => value()}) :: %__MODULE__{}
-      def new!(%__MODULE__{} = value) do
-        ValueObject.new!(__MODULE__, Map.from_struct(value))
-      end
-
-      def new!(attrs) when is_map(attrs) do
-        ValueObject.new!(__MODULE__, attrs)
-      end
-
       @spec new!(value :: value()) :: %__MODULE__{}
-      def new!(value) do
-        ValueObject.new!(__MODULE__, %{value: value})
-      end
+      def new!(%__MODULE__{} = value), do: ValueObject.new!(__MODULE__, Map.from_struct(value))
+      def new!(attrs) when is_map(attrs), do: ValueObject.new!(__MODULE__, attrs)
+      def new!(value), do: ValueObject.new!(__MODULE__, %{value: value})
+    end
+  end
 
+  defp __generated_changeset__ do
+    quote generated: true, location: :keep do
       @doc """
       Returns an `t:Ecto.Changeset.t/0` for a given `t:t/0` value object.
       """
@@ -133,52 +111,93 @@ defmodule Trogon.Ecto.Enum do
         |> Changeset.cast(attrs, [:value])
         |> Changeset.validate_required([:value])
       end
+    end
+  end
 
+  defp __generated_values__(values) do
+    type_ast = Enum.reduce(values, &{:|, [], [&1, &2]})
+
+    value_functions =
+      for value <- values do
+        quote generated: true, location: :keep do
+          @doc """
+          Returns the `#{inspect(unquote(value))}` `t:t/0`.
+          """
+          @spec unquote(value)() :: t()
+          def unquote(value)(), do: %__MODULE__{value: unquote(value)}
+        end
+      end
+
+    quote generated: true, location: :keep do
+      @doc """
+      Returns every supported value.
+      """
       @spec values() :: [unquote(type_ast)]
       def values, do: unquote(values)
 
-      unquote_splicing(value_functions_ast)
+      unquote_splicing(value_functions)
+    end
+  end
 
+  defp __generated_ecto_type__ do
+    quote generated: true, location: :keep do
       @impl Ecto.Type
       def type, do: :string
+    end
+  end
 
-      @impl Ecto.Type
-      def cast(%__MODULE__{value: value} = enum) when value in unquote(values) do
-        {:ok, enum}
+  defp __generated_ecto_cast__(values) do
+    value_clauses =
+      for value <- values do
+        quote generated: true, location: :keep do
+          def cast(unquote(Atom.to_string(value))), do: {:ok, %__MODULE__{value: unquote(value)}}
+        end
       end
 
+    quote generated: true, location: :keep do
       @impl Ecto.Type
-      def cast(%{value: value}) do
-        cast(value)
-      end
-
-      unquote_splicing(cast_as_function_ast)
-
-      @impl Ecto.Type
-      def cast(value) when value in unquote(values) do
-        {:ok, %__MODULE__{value: value}}
-      end
-
-      @impl Ecto.Type
+      def cast(%__MODULE__{value: value} = enum) when value in unquote(values), do: {:ok, enum}
+      def cast(%{value: value}), do: cast(value)
+      unquote_splicing(value_clauses)
+      def cast(value) when value in unquote(values), do: {:ok, %__MODULE__{value: value}}
       def cast(_), do: :error
+    end
+  end
 
-      unquote_splicing(load_functions_ast)
+  defp __generated_ecto_load__(values) do
+    value_clauses =
+      for value <- values do
+        quote generated: true, location: :keep do
+          def load(unquote(Atom.to_string(value))), do: {:ok, %__MODULE__{value: unquote(value)}}
+        end
+      end
+
+    quote generated: true, location: :keep do
       @impl Ecto.Type
+      unquote_splicing(value_clauses)
       def load(_), do: :error
+    end
+  end
 
+  defp __generated_ecto_dump__(values) do
+    quote generated: true, location: :keep do
       @impl Ecto.Type
       @spec dump(any()) :: {:ok, String.t()} | :error
       def dump(%__MODULE__{value: value}) when value in unquote(values), do: {:ok, Atom.to_string(value)}
       def dump(_), do: :error
+    end
+  end
 
+  defp __generated_ecto_comparison__ do
+    quote generated: true, location: :keep do
       @impl Ecto.Type
-      def equal?(%__MODULE__{value: value1}, %__MODULE__{value: value1}) do
-        true
-      end
-
-      @impl Ecto.Type
+      def equal?(%__MODULE__{value: value}, %__MODULE__{value: value}), do: true
       def equal?(_term1, _term2), do: false
+    end
+  end
 
+  defp __generated_protocols__ do
+    quote generated: true, location: :keep do
       unquote(__generated_string_chars_impl__())
       unquote(__generated_jason_impl__())
       unquote(__generated_json_impl__())

--- a/apps/trogon_ecto/mix.exs
+++ b/apps/trogon_ecto/mix.exs
@@ -44,6 +44,7 @@ defmodule Trogon.Ecto.MixProject do
       {:ecto_sql, "~> 3.12", optional: true},
       {:postgrex, "~> 0.19 or ~> 1.0", optional: true},
       {:polymorphic_embed, "~> 5.0"},
+      {:jason, "~> 1.2", optional: true},
 
       # Tools
       {:dialyxir, ">= 0.0.0", only: [:dev], runtime: false},

--- a/apps/trogon_ecto/mix.exs
+++ b/apps/trogon_ecto/mix.exs
@@ -45,6 +45,8 @@ defmodule Trogon.Ecto.MixProject do
       {:postgrex, "~> 0.19 or ~> 1.0", optional: true},
       {:polymorphic_embed, "~> 5.0"},
       {:jason, "~> 1.2", optional: true},
+      {:phoenix, "~> 1.7", optional: true},
+      {:phoenix_html, "~> 3.3 or ~> 4.0", optional: true},
 
       # Tools
       {:dialyxir, ">= 0.0.0", only: [:dev], runtime: false},

--- a/apps/trogon_ecto/test/support/test_support.ex
+++ b/apps/trogon_ecto/test/support/test_support.ex
@@ -272,6 +272,27 @@ defmodule Trogon.Ecto.TestSupport do
     end
   end
 
+  defmodule BankAccountType do
+    @moduledoc false
+    use Trogon.Ecto.Enum, values: [:business, :personal]
+  end
+
+  defmodule BankAccountOpened do
+    @moduledoc false
+    use Trogon.Ecto.ValueObject
+
+    @enforce_keys [:uuid, :type]
+    embedded_schema do
+      field :uuid, :string
+      field :type, Trogon.Ecto.TestSupport.BankAccountType
+    end
+  end
+
+  defmodule BooleanNamedEnum do
+    @moduledoc false
+    use Trogon.Ecto.Enum, values: [true, false]
+  end
+
   def errors_on(changeset) do
     PolymorphicEmbed.traverse_errors(changeset, fn {message, opts} ->
       Regex.replace(~r"%{(\w+)}", message, fn _, key ->

--- a/apps/trogon_ecto/test/trogon/ecto/enum_test.exs
+++ b/apps/trogon_ecto/test/trogon/ecto/enum_test.exs
@@ -173,6 +173,27 @@ defmodule Trogon.Ecto.EnumTest do
     end
   end
 
+  describe "String.Chars.to_string/1" do
+    test "renders the string form of the value" do
+      assert to_string(%BankAccountType{value: :business}) == "business"
+      assert to_string(%BooleanNamedEnum{value: true}) == "true"
+    end
+  end
+
+  describe "Phoenix.Param.to_param/1" do
+    test "returns the string form of the value" do
+      assert Phoenix.Param.to_param(%BankAccountType{value: :business}) == "business"
+    end
+  end
+
+  describe "Phoenix.HTML.Safe.to_iodata/1" do
+    test "renders the string form of the value" do
+      assert %BankAccountType{value: :business}
+             |> Phoenix.HTML.Safe.to_iodata()
+             |> IO.iodata_to_binary() == "business"
+    end
+  end
+
   test "works with embedded schemas" do
     expected_value = %BankAccountOpened{
       uuid: "123",

--- a/apps/trogon_ecto/test/trogon/ecto/enum_test.exs
+++ b/apps/trogon_ecto/test/trogon/ecto/enum_test.exs
@@ -1,0 +1,190 @@
+defmodule Trogon.Ecto.EnumTest do
+  use ExUnit.Case, async: true
+
+  alias Trogon.Ecto.TestSupport.BankAccountOpened
+  alias Trogon.Ecto.TestSupport.BankAccountType
+  alias Trogon.Ecto.TestSupport.BooleanNamedEnum
+  alias Trogon.Ecto.TestSupport.MessageOne
+
+  describe "new/1" do
+    test "returns a value object" do
+      assert {:ok, value} = BankAccountType.new(:business)
+      assert value == %BankAccountType{value: :business}
+    end
+
+    test "returns a value object when passing a map" do
+      assert {:ok, value} = BankAccountType.new(%{value: :business})
+      assert value == %BankAccountType{value: :business}
+    end
+
+    test "returns an error when a validation fails" do
+      assert {:error, changeset} = BankAccountType.new(nil)
+      assert %{value: ["can't be blank"]} = Trogon.Ecto.TestSupport.errors_on(changeset)
+    end
+
+    test "with an invalid value" do
+      assert {:error, changeset} = BankAccountType.new(:invalid)
+      assert %{value: ["is invalid"]} = Trogon.Ecto.TestSupport.errors_on(changeset)
+    end
+
+    test "returns an own-type struct unchanged" do
+      existing = %BankAccountType{value: :business}
+      assert BankAccountType.new(existing) == {:ok, existing}
+    end
+
+    test "raises an ArgumentError for a foreign struct" do
+      assert_raise ArgumentError, fn ->
+        BankAccountType.new(%MessageOne{title: "Hello"})
+      end
+    end
+  end
+
+  describe "new!/1" do
+    test "creates a value object" do
+      assert %BankAccountType{value: :business} = BankAccountType.new!(:business)
+    end
+
+    test "creates a value object when passing a map" do
+      assert %BankAccountType{value: :business} = BankAccountType.new!(%{value: :business})
+    end
+
+    test "raises an error when a validation fails" do
+      assert_raise Ecto.InvalidChangesetError, fn ->
+        BankAccountType.new!(nil)
+      end
+    end
+
+    test "raises an error with an invalid value" do
+      assert_raise Ecto.InvalidChangesetError, fn ->
+        BankAccountType.new!(:invalid)
+      end
+    end
+
+    test "returns an own-type struct unchanged" do
+      existing = %BankAccountType{value: :business}
+      assert BankAccountType.new!(existing) == existing
+    end
+
+    test "raises an ArgumentError for a foreign struct" do
+      assert_raise ArgumentError, fn ->
+        BankAccountType.new!(%MessageOne{title: "Hello"})
+      end
+    end
+  end
+
+  test "values/0" do
+    assert BankAccountType.values() == [:business, :personal]
+  end
+
+  test "specific enum values" do
+    assert BankAccountType.business() == %BankAccountType{value: :business}
+    assert BankAccountType.personal() == %BankAccountType{value: :personal}
+  end
+
+  describe "type/1" do
+    test "returns the type of the enum" do
+      assert BankAccountType.type() == :string
+    end
+  end
+
+  describe "cast/1" do
+    test "casts a map" do
+      assert BankAccountType.cast(%{value: :business}) == {:ok, %BankAccountType{value: :business}}
+    end
+
+    test "casts atom values" do
+      assert BankAccountType.cast(:business) == {:ok, %BankAccountType{value: :business}}
+      assert BankAccountType.cast(:personal) == {:ok, %BankAccountType{value: :personal}}
+      assert BankAccountType.cast(:invalid) == :error
+    end
+
+    test "casts string values" do
+      assert BankAccountType.cast("business") == {:ok, %BankAccountType{value: :business}}
+      assert BankAccountType.cast("personal") == {:ok, %BankAccountType{value: :personal}}
+      assert BankAccountType.cast("invalid") == :error
+    end
+
+    test "casts existing struct" do
+      existing = %BankAccountType{value: :business}
+      assert BankAccountType.cast(existing) == {:ok, existing}
+    end
+  end
+
+  describe "load/1" do
+    test "loads string values" do
+      assert BankAccountType.load("business") == {:ok, %BankAccountType{value: :business}}
+      assert BankAccountType.load("personal") == {:ok, %BankAccountType{value: :personal}}
+      assert BankAccountType.load("invalid") == :error
+    end
+
+    test "returns error for non-string values" do
+      assert BankAccountType.load(:business) == :error
+      assert BankAccountType.load(123) == :error
+      assert BankAccountType.load(%{}) == :error
+    end
+  end
+
+  describe "dump/1" do
+    test "dumps struct to string" do
+      assert BankAccountType.dump(%BankAccountType{value: :business}) == {:ok, "business"}
+      assert BankAccountType.dump(%BankAccountType{value: :personal}) == {:ok, "personal"}
+    end
+
+    test "returns error for invalid values" do
+      assert BankAccountType.dump(%BankAccountType{value: :invalid}) == :error
+      assert BankAccountType.dump("business") == :error
+      assert BankAccountType.dump(:business) == :error
+      assert BankAccountType.dump(%{}) == :error
+    end
+  end
+
+  describe "equal?/2" do
+    test "returns true for matching values" do
+      assert BankAccountType.equal?(%BankAccountType{value: :business}, %BankAccountType{value: :business})
+      assert BankAccountType.equal?(%BankAccountType{value: :personal}, %BankAccountType{value: :personal})
+    end
+
+    test "returns false for different values" do
+      refute BankAccountType.equal?(%BankAccountType{value: :business}, %BankAccountType{value: :personal})
+    end
+
+    test "returns false for non-struct values" do
+      refute BankAccountType.equal?(%BankAccountType{value: :business}, :business)
+      refute BankAccountType.equal?(:business, %BankAccountType{value: :business})
+      refute BankAccountType.equal?("business", "business")
+    end
+  end
+
+  describe "JSON encoding" do
+    test "Jason.encode!/1 encodes to the value" do
+      assert Jason.encode!(%BankAccountType{value: :business}) == ~s("business")
+    end
+
+    test "JSON.encode!/1 encodes to the value" do
+      assert JSON.encode!(%BankAccountType{value: :business}) == ~s("business")
+    end
+
+    test "encodes boolean-named values as strings, matching dump/1" do
+      value = %BooleanNamedEnum{value: true}
+
+      assert BooleanNamedEnum.dump(value) == {:ok, "true"}
+      assert Jason.encode!(value) == ~s("true")
+      assert JSON.encode!(value) == ~s("true")
+    end
+  end
+
+  test "works with embedded schemas" do
+    expected_value = %BankAccountOpened{
+      uuid: "123",
+      type: %BankAccountType{value: :business}
+    }
+
+    given_value =
+      BankAccountOpened.new!(%{
+        uuid: "123",
+        type: BankAccountType.new!(:business)
+      })
+
+    assert expected_value == given_value
+  end
+end

--- a/apps/trogon_ecto/test/trogon/ecto/enum_test.exs
+++ b/apps/trogon_ecto/test/trogon/ecto/enum_test.exs
@@ -37,6 +37,11 @@ defmodule Trogon.Ecto.EnumTest do
         BankAccountType.new(%MessageOne{title: "Hello"})
       end
     end
+
+    test "rejects a hand-built struct holding an unsupported value" do
+      assert {:error, changeset} = BankAccountType.new(%BankAccountType{value: :invalid})
+      assert %{value: ["is invalid"]} = Trogon.Ecto.TestSupport.errors_on(changeset)
+    end
   end
 
   describe "new!/1" do
@@ -68,6 +73,12 @@ defmodule Trogon.Ecto.EnumTest do
     test "raises an ArgumentError for a foreign struct" do
       assert_raise ArgumentError, fn ->
         BankAccountType.new!(%MessageOne{title: "Hello"})
+      end
+    end
+
+    test "raises for a hand-built struct holding an unsupported value" do
+      assert_raise Ecto.InvalidChangesetError, fn ->
+        BankAccountType.new!(%BankAccountType{value: :invalid})
       end
     end
   end
@@ -107,6 +118,10 @@ defmodule Trogon.Ecto.EnumTest do
     test "casts existing struct" do
       existing = %BankAccountType{value: :business}
       assert BankAccountType.cast(existing) == {:ok, existing}
+    end
+
+    test "rejects a hand-built struct holding an unsupported value" do
+      assert BankAccountType.cast(%BankAccountType{value: :invalid}) == :error
     end
   end
 


### PR DESCRIPTION
- `Trogon.Commanded.Enum` has no Commanded dependency: it is `Ecto.Schema` plus `Ecto.Type` plus `Ecto.Enum`. Consumers that only need the Ecto primitive should not have to depend on the event sourcing stack to get it, the same reasoning that already moved `ValueObject` into this package.
- The proto driven option is left out on purpose. Deriving values from a protobuf enum belongs in the layer that already owns the proto stack, and `trogon_ecto` should not grow a `protobuf` or `trogon_proto` dependency.
- JSON encoding is optional rather than hardcoded, matching how `trogon_object_id` handles it, so this package keeps working for consumers that use neither `Jason` nor the native `JSON` module.
- Encoders emit the string form of the value so that JSON output and `dump/1` agree for every enum, including one whose values are named `true` or `false`.

Closes nothing. `Trogon.Commanded.Enum` is untouched, so this is additive and nothing needs to migrate yet.