### PR TITLE
feat(trogon_ecto): add bounded string type

### DIFF
--- a/apps/trogon_ecto/lib/trogon/ecto/bounded_string.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/bounded_string.ex
@@ -1,7 +1,7 @@
 defmodule Trogon.Ecto.BoundedString do
   @moduledoc """
-  A string field with a maximum length, declared on the field instead of
-  restated in every changeset.
+  A string field with a maximum length, enforced by the field rather than by
+  every changeset that touches it.
 
       defmodule Product do
         use Ecto.Schema
@@ -12,62 +12,28 @@ defmodule Trogon.Ecto.BoundedString do
         end
       end
 
-  `:max_length` is required and must be a positive integer. `:truncate` is
-  optional and defaults to `false`.
+  ## Options
 
-  ## When a value is too long
+  - `:max_length` - required, a positive integer. Counted in characters, not
+    bytes, so `max_length: 80` can outgrow a `varchar(80)` column.
+  - `:truncate` - cut oversized values to fit instead of rejecting them.
+    Defaults to `false`.
 
-  The changeset fails the way `Ecto.Changeset.validate_length/3` fails on a
-  `:max` violation: the message `"should be at most %{count} character(s)"`,
-  alongside `count`, `validation: :length` and `kind: :max`. Whatever already
-  renders your validation errors keeps working, and the wording stays consistent
-  with the fields you bound by hand.
+  An oversized value fails the changeset the way
+  `Ecto.Changeset.validate_length/3` does on a `:max` violation, with
+  `"should be at most %{count} character(s)"`, `count`, `validation: :length`
+  and `kind: :max`. Match on those rather than on `:type`.
 
-  The reason to declare the bound here rather than call `validate_length/3` is
-  that it cannot be forgotten. It applies to every changeset that touches the
-  field, and to code that writes the field without a changeset at all, which
-  would otherwise reach the database unchecked.
+  Under `truncate: true` the value is cut during `cast`, so the changeset holds
+  the shortened string. Graphemes are never split.
 
-  If you render errors by matching on metadata, match `validation: :length` and
-  `kind: :max`. Avoid matching on `:type`, which holds this type rather than
-  `:string` when the error comes from a changeset.
-
-  ## Truncating instead of failing
-
-  With `truncate: true` an oversized value is cut to fit instead of rejected.
-
-  Reach for it when the text is something you are recording rather than
-  validating, and losing the tail beats losing the write: a vendor's error
-  message, an upstream description, a log line. Leave it off for anything a
-  person typed and expects back verbatim, where silently changing their input is
-  worse than telling them it was too long.
-
-  The value is cut as it is cast, so the shortened string is what the changeset
-  holds and what every later validation sees, not a surprise applied on the way
-  to the database. Characters are never split in half.
-
-  ## Rows that are already too long
-
-  Reads are never bounded, so adding a bound, or tightening one, does not break
-  existing rows. Updating other fields on such a row keeps working too.
-
-  Writing the too-long value back is what fails, which is usually what you want,
-  since that row no longer satisfies the field. Migrate it, widen the bound, or
-  set `truncate: true` to accept the loss.
-
-  ## Sizing the column
-
-  The bound counts characters, while a `varchar(n)` column counts bytes, and
-  multi-byte text takes more bytes than it has characters. Give the column room
-  to spare, or make it `text` and let this type be the limit.
+  Reads are unbounded, so adding or tightening a bound never breaks existing
+  rows. Writing a too-long value back is what fails.
   """
 
   use Ecto.ParameterizedType
 
-  @typedoc """
-  The bound and policy for a field, built by Ecto from the options given to
-  `field/3`.
-  """
+  @typedoc "A field's bound and truncation policy, built by Ecto from `field/3`."
   @type params :: %{max_length: pos_integer(), truncate: boolean()}
 
   @impl Ecto.ParameterizedType

--- a/apps/trogon_ecto/lib/trogon/ecto/bounded_string.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/bounded_string.ex
@@ -1,18 +1,44 @@
 defmodule Trogon.Ecto.BoundedString do
+  # Ecto skips its own `field/3` option check for parameterized types, so these
+  # have to be accepted here. Mirrors `@field_opts` in `Ecto.Schema`.
+  @ecto_field_opts [
+    :default,
+    :source,
+    :autogenerate,
+    :read_after_writes,
+    :virtual,
+    :primary_key,
+    :load_in_query,
+    :redact,
+    :foreign_key,
+    :on_replace,
+    :defaults,
+    :type,
+    :where,
+    :references,
+    :skip_default_validation,
+    :writable,
+    :on_writable_violation,
+    :field,
+    :schema
+  ]
+
   @opts_schema NimbleOptions.new!(
-                 max_length: [
-                   type: :pos_integer,
-                   required: true,
-                   doc: """
-                   Maximum length, counted in characters rather than bytes, so
-                   `max_length: 80` can outgrow a `varchar(80)` column.
-                   """
-                 ],
-                 truncate: [
-                   type: :boolean,
-                   default: false,
-                   doc: "Cut oversized values to fit instead of rejecting them."
-                 ]
+                 [
+                   max_length: [
+                     type: :pos_integer,
+                     required: true,
+                     doc: """
+                     Maximum length, counted in characters rather than bytes, so
+                     `max_length: 80` can outgrow a `varchar(80)` column.
+                     """
+                   ],
+                   truncate: [
+                     type: :boolean,
+                     default: false,
+                     doc: "Cut oversized values to fit instead of rejecting them."
+                   ]
+                 ] ++ Enum.map(@ecto_field_opts, &{&1, [type: :any, doc: false]})
                )
 
   @moduledoc """
@@ -52,8 +78,8 @@ defmodule Trogon.Ecto.BoundedString do
   @spec init(keyword()) :: params()
   def init(opts) do
     opts
-    |> Keyword.take([:max_length, :truncate])
     |> NimbleOptions.validate!(@opts_schema)
+    |> Keyword.take([:max_length, :truncate])
     |> Map.new()
   end
 

--- a/apps/trogon_ecto/lib/trogon/ecto/bounded_string.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/bounded_string.ex
@@ -1,4 +1,20 @@
 defmodule Trogon.Ecto.BoundedString do
+  @opts_schema NimbleOptions.new!(
+                 max_length: [
+                   type: :pos_integer,
+                   required: true,
+                   doc: """
+                   Maximum length, counted in characters rather than bytes, so
+                   `max_length: 80` can outgrow a `varchar(80)` column.
+                   """
+                 ],
+                 truncate: [
+                   type: :boolean,
+                   default: false,
+                   doc: "Cut oversized values to fit instead of rejecting them."
+                 ]
+               )
+
   @moduledoc """
   A string field with a maximum length, enforced by the field rather than by
   every changeset that touches it.
@@ -14,10 +30,7 @@ defmodule Trogon.Ecto.BoundedString do
 
   ## Options
 
-  - `:max_length` - required, a positive integer. Counted in characters, not
-    bytes, so `max_length: 80` can outgrow a `varchar(80)` column.
-  - `:truncate` - cut oversized values to fit instead of rejecting them.
-    Defaults to `false`.
+  #{NimbleOptions.docs(@opts_schema)}
 
   An oversized value fails the changeset with
   `"should be at most %{count} character(s)"` and the metadata `count`,
@@ -38,40 +51,10 @@ defmodule Trogon.Ecto.BoundedString do
   @impl Ecto.ParameterizedType
   @spec init(keyword()) :: params()
   def init(opts) do
-    %{max_length: max_length!(opts), truncate: truncate!(opts)}
-  end
-
-  defp max_length!(opts) do
-    case Keyword.fetch(opts, :max_length) do
-      {:ok, max_length} ->
-        validate_max_length!(max_length)
-
-      :error ->
-        raise ArgumentError,
-              "missing :max_length for Trogon.Ecto.BoundedString, expected a positive integer"
-    end
-  end
-
-  defp validate_max_length!(max_length) when is_integer(max_length) and max_length > 0, do: max_length
-
-  defp validate_max_length!(other) do
-    raise ArgumentError,
-          "invalid :max_length #{inspect(other)} for Trogon.Ecto.BoundedString, " <>
-            "expected a positive integer"
-  end
-
-  defp truncate!(opts) do
     opts
-    |> Keyword.get(:truncate, false)
-    |> validate_truncate!()
-  end
-
-  defp validate_truncate!(truncate) when is_boolean(truncate), do: truncate
-
-  defp validate_truncate!(other) do
-    raise ArgumentError,
-          "invalid :truncate #{inspect(other)} for Trogon.Ecto.BoundedString, " <>
-            "expected a boolean"
+    |> Keyword.take([:max_length, :truncate])
+    |> NimbleOptions.validate!(@opts_schema)
+    |> Map.new()
   end
 
   @impl Ecto.ParameterizedType

--- a/apps/trogon_ecto/lib/trogon/ecto/bounded_string.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/bounded_string.ex
@@ -1,114 +1,75 @@
 defmodule Trogon.Ecto.BoundedString do
   @moduledoc """
-  An `Ecto.ParameterizedType` for a string bounded to a maximum length, declared
-  at the field rather than restated in every changeset.
+  A string field with a maximum length, declared on the field instead of
+  restated in every changeset.
 
-      field :title, Trogon.Ecto.BoundedString, max_length: 80
-      field :error, Trogon.Ecto.BoundedString, max_length: 256, truncate: true
+      defmodule Product do
+        use Ecto.Schema
 
-  The bound travels with the field, so it holds for every write path into it,
-  including the ones that never call `Ecto.Changeset.validate_length/3`. It is
-  enforced twice over: on `cast/2`, where it produces a validation error you can
-  render, and again on `dump/3`, which catches the paths that skip casting
-  altogether (`Ecto.Changeset.put_change/3`, `Ecto.Changeset.change/2`,
-  `struct!/2`).
+        schema "products" do
+          field :name, Trogon.Ecto.BoundedString, max_length: 80
+          field :import_note, Trogon.Ecto.BoundedString, max_length: 256, truncate: true
+        end
+      end
 
-  ## The `:max_length` option
+  `:max_length` is required and must be a positive integer. `:truncate` is
+  optional and defaults to `false`.
 
-  Required, a positive integer. Counts graphemes, matching
-  `Ecto.Changeset.validate_length/3` and never splitting a character. The
-  serialized byte size of multi-byte text can exceed it, so this bounds order of
-  magnitude, not exact bytes; size a `varchar` column accordingly, or prefer
-  `text` and let the type be the bound.
+  ## When a value is too long
 
-  ## The `:truncate` option
+  The changeset fails the way `Ecto.Changeset.validate_length/3` fails on a
+  `:max` violation: the message `"should be at most %{count} character(s)"`,
+  alongside `count`, `validation: :length` and `kind: :max`. Whatever already
+  renders your validation errors keeps working, and the wording stays consistent
+  with the fields you bound by hand.
 
-  Decides what an oversized value means.
+  The reason to declare the bound here rather than call `validate_length/3` is
+  that it cannot be forgotten. It applies to every changeset that touches the
+  field, and to code that writes the field without a changeset at all, which
+  would otherwise reach the database unchecked.
 
-  - `false` (the default) - an oversized value is a cast error, carrying the same
-    message and metadata (`count`, `validation: :length`, `kind: :max`) that
-    `Ecto.Changeset.validate_length/3` would have produced, so existing error
-    traversal and translation keep working unchanged.
-  - `true` - the value is silently cut at the bound instead.
+  If you render errors by matching on metadata, match `validation: :length` and
+  `kind: :max`. Avoid matching on `:type`, which holds this type rather than
+  `:string` when the error comes from a changeset.
 
-  Reserve `truncate: true` for diagnostic text sourced from unbounded external
-  payloads (vendor HTTP bodies, gRPC status messages), where recording a lossy
-  detail beats failing the command that records it. For anything a user typed and
-  expects back verbatim, leave it off and let the cast fail.
+  ## Truncating instead of failing
 
-  Truncation happens on cast, so the shortened value is what the changeset holds
-  and what every later validation sees, not a surprise applied on the way to the
-  database.
+  With `truncate: true` an oversized value is cut to fit instead of rejected.
 
-  ## The `:type` metadata differs inside a changeset
+  Reach for it when the text is something you are recording rather than
+  validating, and losing the tail beats losing the write: a vendor's error
+  message, an upstream description, a log line. Leave it off for anything a
+  person typed and expects back verbatim, where silently changing their input is
+  worse than telling them it was too long.
 
-  `cast/2` returns `type: :string`, but `Ecto.Changeset` overwrites the `:type`
-  metadata of a custom type error with the type the field was declared as. A
-  violation surfaced through a changeset therefore carries
-  `type: {:parameterized, {Trogon.Ecto.BoundedString, params}}`, not
-  `type: :string`.
+  The value is cut as it is cast, so the shortened string is what the changeset
+  holds and what every later validation sees, not a surprise applied on the way
+  to the database. Characters are never split in half.
 
-  That is the declared type rather than the stored one, and it is the more useful
-  of the two, since it names which type rejected the value and carries its
-  `:max_length`. Resolve it to the storage type with `Ecto.Type.type/1` when a
-  primitive is what you need:
+  ## Rows that are already too long
 
-      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
-      iex> Ecto.Type.type({:parameterized, {Trogon.Ecto.BoundedString, params}})
-      :string
+  Reads are never bounded, so adding a bound, or tightening one, does not break
+  existing rows. Updating other fields on such a row keeps working too.
 
-  Error translation should match on `validation: :length` and `kind: :max`, which
-  survive both paths. Code that renders `:type` must also tolerate a non-string
-  term there, since interpolating it with `to_string/1` raises for a tuple.
+  Writing the too-long value back is what fails, which is usually what you want,
+  since that row no longer satisfies the field. Migrate it, widen the bound, or
+  set `truncate: true` to accept the loss.
 
-  ## Reads are lenient, writes are not
+  ## Sizing the column
 
-  `load/3` accepts any binary, whatever the bound, while `cast/2` and `dump/3`
-  both enforce it. A column whose values predate the bound, or predate a
-  tightening of it, still reads cleanly; only writes are held to it.
-
-  That asymmetry is deliberate, and it is what makes tightening a bound
-  survivable. Ecto dumps only the fields a changeset actually changed, so a
-  legacy row whose oversized field is left alone updates normally:
-
-      # works, even though `title` is over the bound in the database
-      record |> Ecto.Changeset.change(%{other_field: "new"}) |> Repo.update()
-
-  What does fail is writing an oversized value back, whether it came from
-  `struct!/2` or from a row loaded before the bound existed. Copying a legacy row
-  verbatim is the case to watch. Treat the resulting `Ecto.ChangeError` as the
-  intended answer: the row no longer satisfies the field's contract, so either
-  migrate it, widen the bound, or set `truncate: true` to accept the loss.
+  The bound counts characters, while a `varchar(n)` column counts bytes, and
+  multi-byte text takes more bytes than it has characters. Give the column room
+  to spare, or make it `text` and let this type be the limit.
   """
 
   use Ecto.ParameterizedType
 
+  @typedoc """
+  The bound and policy for a field, built by Ecto from the options given to
+  `field/3`.
+  """
   @type params :: %{max_length: pos_integer(), truncate: boolean()}
 
-  @doc """
-  Initializes the parameterized type from the `:max_length` and `:truncate` options.
-
-  Ecto injects extra keys (`:field`, `:schema`) into `opts`; they are ignored.
-  Raises `ArgumentError` when `:max_length` is missing or is not a positive
-  integer, or when `:truncate` is not a boolean.
-
-  ## Examples
-
-      iex> Trogon.Ecto.BoundedString.init(max_length: 80)
-      %{max_length: 80, truncate: false}
-
-      iex> Trogon.Ecto.BoundedString.init(max_length: 256, truncate: true)
-      %{max_length: 256, truncate: true}
-
-      iex> Trogon.Ecto.BoundedString.init([])
-      ** (ArgumentError) missing :max_length for Trogon.Ecto.BoundedString, expected a positive integer
-
-      iex> Trogon.Ecto.BoundedString.init(max_length: 0)
-      ** (ArgumentError) invalid :max_length 0 for Trogon.Ecto.BoundedString, expected a positive integer
-
-      iex> Trogon.Ecto.BoundedString.init(max_length: 80, truncate: :yes)
-      ** (ArgumentError) invalid :truncate :yes for Trogon.Ecto.BoundedString, expected a boolean
-  """
   @impl Ecto.ParameterizedType
   @spec init(keyword()) :: params()
   def init(opts) do
@@ -148,55 +109,10 @@ defmodule Trogon.Ecto.BoundedString do
             "expected a boolean"
   end
 
-  @doc """
-  Returns the underlying Ecto type used to persist the value, always `:string`.
-
-  ## Examples
-
-      iex> params = Trogon.Ecto.BoundedString.init(max_length: 80)
-      iex> Trogon.Ecto.BoundedString.type(params)
-      :string
-  """
   @impl Ecto.ParameterizedType
   @spec type(params()) :: :string
   def type(_params), do: :string
 
-  @doc """
-  Casts a binary, holding it to the configured bound.
-
-  A value within the bound is returned as-is, and `nil` passes through. An
-  oversized value is cut at the bound under `truncate: true`, and otherwise
-  returns the `Ecto.Changeset.validate_length/3` error metadata for a `:max`
-  violation. Anything that is not a binary returns `:error`.
-
-  ## Examples
-
-      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
-      iex> Trogon.Ecto.BoundedString.cast("hello", params)
-      {:ok, "hello"}
-
-      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
-      iex> Trogon.Ecto.BoundedString.cast(nil, params)
-      {:ok, nil}
-
-      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
-      iex> Trogon.Ecto.BoundedString.cast("hello world", params)
-      {:error, [message: "should be at most %{count} character(s)", count: 5, validation: :length, kind: :max, type: :string]}
-
-      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5, truncate: true)
-      iex> Trogon.Ecto.BoundedString.cast("hello world", params)
-      {:ok, "hello"}
-
-  Graphemes are counted, and never split:
-
-      iex> params = Trogon.Ecto.BoundedString.init(max_length: 2, truncate: true)
-      iex> Trogon.Ecto.BoundedString.cast("héllo", params)
-      {:ok, "hé"}
-
-      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
-      iex> Trogon.Ecto.BoundedString.cast(:hello, params)
-      :error
-  """
   @impl Ecto.ParameterizedType
   @spec cast(term(), params()) :: {:ok, String.t() | nil} | {:error, keyword()} | :error
   def cast(nil, _params), do: {:ok, nil}
@@ -228,27 +144,6 @@ defmodule Trogon.Ecto.BoundedString do
     ]
   end
 
-  @doc """
-  Loads a binary from the database, without holding it to the bound.
-
-  ## Examples
-
-      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
-      iex> Trogon.Ecto.BoundedString.load("hello", & &1, params)
-      {:ok, "hello"}
-
-      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
-      iex> Trogon.Ecto.BoundedString.load("a value stored before the bound", & &1, params)
-      {:ok, "a value stored before the bound"}
-
-      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
-      iex> Trogon.Ecto.BoundedString.load(nil, & &1, params)
-      {:ok, nil}
-
-      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
-      iex> Trogon.Ecto.BoundedString.load(123, & &1, params)
-      :error
-  """
   @impl Ecto.ParameterizedType
   @spec load(term(), (Ecto.Type.t(), term() -> {:ok, term()} | :error), params()) ::
           {:ok, String.t() | nil} | :error
@@ -256,47 +151,6 @@ defmodule Trogon.Ecto.BoundedString do
   def load(value, _loader, _params) when is_binary(value), do: {:ok, value}
   def load(_value, _loader, _params), do: :error
 
-  @doc """
-  Dumps a binary, holding it to the configured bound.
-
-  Applies the same policy as `cast/2`, because `cast/2` is not the only way into
-  a field. `Ecto.Changeset.put_change/3`, `Ecto.Changeset.change/2` and
-  `struct!/2` all write a field without casting it, so dump is the last gate
-  before the value reaches the database.
-
-  A dump failure is a `:error` rather than the metadata `cast/2` returns, since
-  `c:Ecto.ParameterizedType.dump/3` has nowhere to put it; Ecto raises
-  `Ecto.ChangeError`. That is the right shape for this failure: user input
-  arrives through `cast/2`, so an oversized value here is a bug in the calling
-  code, not something to render back as a validation error.
-
-  ## Examples
-
-      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
-      iex> Trogon.Ecto.BoundedString.dump("hello", & &1, params)
-      {:ok, "hello"}
-
-      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
-      iex> Trogon.Ecto.BoundedString.dump(nil, & &1, params)
-      {:ok, nil}
-
-  An oversized value is refused, so a field written without casting cannot
-  escape the bound:
-
-      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
-      iex> Trogon.Ecto.BoundedString.dump("hello world", & &1, params)
-      :error
-
-  Under `truncate: true` it is cut instead, matching `cast/2`:
-
-      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5, truncate: true)
-      iex> Trogon.Ecto.BoundedString.dump("hello world", & &1, params)
-      {:ok, "hello"}
-
-      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
-      iex> Trogon.Ecto.BoundedString.dump(123, & &1, params)
-      :error
-  """
   @impl Ecto.ParameterizedType
   @spec dump(term(), (Ecto.Type.t(), term() -> {:ok, term()} | :error), params()) ::
           {:ok, String.t() | nil} | :error
@@ -311,16 +165,6 @@ defmodule Trogon.Ecto.BoundedString do
 
   def dump(_value, _dumper, _params), do: :error
 
-  @doc """
-  Returns how the value is persisted when the type is used inside an embed,
-  always `:dump`.
-
-  ## Examples
-
-      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
-      iex> Trogon.Ecto.BoundedString.embed_as(:json, params)
-      :dump
-  """
   @impl Ecto.ParameterizedType
   @spec embed_as(atom(), params()) :: :dump
   def embed_as(_format, _params), do: :dump

--- a/apps/trogon_ecto/lib/trogon/ecto/bounded_string.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/bounded_string.ex
@@ -1,44 +1,18 @@
 defmodule Trogon.Ecto.BoundedString do
-  # Ecto skips its own `field/3` option check for parameterized types, so these
-  # have to be accepted here. Mirrors `@field_opts` in `Ecto.Schema`.
-  @ecto_field_opts [
-    :default,
-    :source,
-    :autogenerate,
-    :read_after_writes,
-    :virtual,
-    :primary_key,
-    :load_in_query,
-    :redact,
-    :foreign_key,
-    :on_replace,
-    :defaults,
-    :type,
-    :where,
-    :references,
-    :skip_default_validation,
-    :writable,
-    :on_writable_violation,
-    :field,
-    :schema
-  ]
-
   @opts_schema NimbleOptions.new!(
-                 [
-                   max_length: [
-                     type: :pos_integer,
-                     required: true,
-                     doc: """
-                     Maximum length, counted in characters rather than bytes, so
-                     `max_length: 80` can outgrow a `varchar(80)` column.
-                     """
-                   ],
-                   truncate: [
-                     type: :boolean,
-                     default: false,
-                     doc: "Cut oversized values to fit instead of rejecting them."
-                   ]
-                 ] ++ Enum.map(@ecto_field_opts, &{&1, [type: :any, doc: false]})
+                 max_length: [
+                   type: :pos_integer,
+                   required: true,
+                   doc: """
+                   Maximum length, counted in characters rather than bytes, so
+                   `max_length: 80` can outgrow a `varchar(80)` column.
+                   """
+                 ],
+                 truncate: [
+                   type: :boolean,
+                   default: false,
+                   doc: "Cut oversized values to fit instead of rejecting them."
+                 ]
                )
 
   @moduledoc """
@@ -78,8 +52,8 @@ defmodule Trogon.Ecto.BoundedString do
   @spec init(keyword()) :: params()
   def init(opts) do
     opts
-    |> NimbleOptions.validate!(@opts_schema)
     |> Keyword.take([:max_length, :truncate])
+    |> NimbleOptions.validate!(@opts_schema)
     |> Map.new()
   end
 

--- a/apps/trogon_ecto/lib/trogon/ecto/bounded_string.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/bounded_string.ex
@@ -19,10 +19,9 @@ defmodule Trogon.Ecto.BoundedString do
   - `:truncate` - cut oversized values to fit instead of rejecting them.
     Defaults to `false`.
 
-  An oversized value fails the changeset the way
-  `Ecto.Changeset.validate_length/3` does on a `:max` violation, with
-  `"should be at most %{count} character(s)"`, `count`, `validation: :length`
-  and `kind: :max`. Match on those rather than on `:type`.
+  An oversized value fails the changeset with
+  `"should be at most %{count} character(s)"` and the metadata `count`,
+  `validation: :length` and `kind: :max`.
 
   Under `truncate: true` the value is cut during `cast`, so the changeset holds
   the shortened string. Graphemes are never split.

--- a/apps/trogon_ecto/lib/trogon/ecto/bounded_string.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/bounded_string.ex
@@ -7,7 +7,11 @@ defmodule Trogon.Ecto.BoundedString do
       field :error, Trogon.Ecto.BoundedString, max_length: 256, truncate: true
 
   The bound travels with the field, so it holds for every write path into it,
-  including the ones that never call `Ecto.Changeset.validate_length/3`.
+  including the ones that never call `Ecto.Changeset.validate_length/3`. It is
+  enforced twice over: on `cast/2`, where it produces a validation error you can
+  render, and again on `dump/3`, which catches the paths that skip casting
+  altogether (`Ecto.Changeset.put_change/3`, `Ecto.Changeset.change/2`,
+  `struct!/2`).
 
   ## The `:max_length` option
 
@@ -22,9 +26,9 @@ defmodule Trogon.Ecto.BoundedString do
   Decides what an oversized value means.
 
   - `false` (the default) - an oversized value is a cast error, carrying the same
-    message and metadata (`count`, `validation: :length`, `kind: :max`,
-    `type: :string`) that `Ecto.Changeset.validate_length/3` would have produced,
-    so existing error traversal and translation keep working unchanged.
+    message and metadata (`count`, `validation: :length`, `kind: :max`) that
+    `Ecto.Changeset.validate_length/3` would have produced, so existing error
+    traversal and translation keep working unchanged.
   - `true` - the value is silently cut at the bound instead.
 
   Reserve `truncate: true` for diagnostic text sourced from unbounded external
@@ -36,12 +40,45 @@ defmodule Trogon.Ecto.BoundedString do
   and what every later validation sees, not a surprise applied on the way to the
   database.
 
-  ## Bounds are not enforced on load
+  ## The `:type` metadata differs inside a changeset
 
-  `load/3` accepts any binary, whatever the bound. A column whose values predate
-  the bound, or predate a tightening of it, still reads cleanly; only new writes
-  are held to it. Tighten a bound when you are willing to have reads and writes
-  disagree until the existing rows are migrated.
+  `cast/2` returns `type: :string`, but `Ecto.Changeset` overwrites the `:type`
+  metadata of a custom type error with the type the field was declared as. A
+  violation surfaced through a changeset therefore carries
+  `type: {:parameterized, {Trogon.Ecto.BoundedString, params}}`, not
+  `type: :string`.
+
+  That is the declared type rather than the stored one, and it is the more useful
+  of the two, since it names which type rejected the value and carries its
+  `:max_length`. Resolve it to the storage type with `Ecto.Type.type/1` when a
+  primitive is what you need:
+
+      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
+      iex> Ecto.Type.type({:parameterized, {Trogon.Ecto.BoundedString, params}})
+      :string
+
+  Error translation should match on `validation: :length` and `kind: :max`, which
+  survive both paths. Code that renders `:type` must also tolerate a non-string
+  term there, since interpolating it with `to_string/1` raises for a tuple.
+
+  ## Reads are lenient, writes are not
+
+  `load/3` accepts any binary, whatever the bound, while `cast/2` and `dump/3`
+  both enforce it. A column whose values predate the bound, or predate a
+  tightening of it, still reads cleanly; only writes are held to it.
+
+  That asymmetry is deliberate, and it is what makes tightening a bound
+  survivable. Ecto dumps only the fields a changeset actually changed, so a
+  legacy row whose oversized field is left alone updates normally:
+
+      # works, even though `title` is over the bound in the database
+      record |> Ecto.Changeset.change(%{other_field: "new"}) |> Repo.update()
+
+  What does fail is writing an oversized value back, whether it came from
+  `struct!/2` or from a row loaded before the bound existed. Copying a legacy row
+  verbatim is the case to watch. Treat the resulting `Ecto.ChangeError` as the
+  intended answer: the row no longer satisfies the field's contract, so either
+  migrate it, widen the bound, or set `truncate: true` to accept the loss.
   """
 
   use Ecto.ParameterizedType
@@ -165,14 +202,21 @@ defmodule Trogon.Ecto.BoundedString do
   def cast(nil, _params), do: {:ok, nil}
 
   def cast(value, %{max_length: max_length, truncate: truncate}) when is_binary(value) do
-    cond do
-      String.length(value) <= max_length -> {:ok, value}
-      truncate -> {:ok, String.slice(value, 0, max_length)}
-      true -> {:error, too_long_error(max_length)}
+    case apply_bound(value, max_length, truncate) do
+      {:ok, value} -> {:ok, value}
+      :too_long -> {:error, too_long_error(max_length)}
     end
   end
 
   def cast(_value, _params), do: :error
+
+  defp apply_bound(value, max_length, truncate) do
+    cond do
+      String.length(value) <= max_length -> {:ok, value}
+      truncate -> {:ok, String.slice(value, 0, max_length)}
+      true -> :too_long
+    end
+  end
 
   defp too_long_error(max_length) do
     [
@@ -213,11 +257,18 @@ defmodule Trogon.Ecto.BoundedString do
   def load(_value, _loader, _params), do: :error
 
   @doc """
-  Dumps a binary, strictly.
+  Dumps a binary, holding it to the configured bound.
 
-  The bound was already applied on cast, so a value reaching here is either
-  within it or was loaded from a column that predates it; either way it is
-  persisted as it stands.
+  Applies the same policy as `cast/2`, because `cast/2` is not the only way into
+  a field. `Ecto.Changeset.put_change/3`, `Ecto.Changeset.change/2` and
+  `struct!/2` all write a field without casting it, so dump is the last gate
+  before the value reaches the database.
+
+  A dump failure is a `:error` rather than the metadata `cast/2` returns, since
+  `c:Ecto.ParameterizedType.dump/3` has nowhere to put it; Ecto raises
+  `Ecto.ChangeError`. That is the right shape for this failure: user input
+  arrives through `cast/2`, so an oversized value here is a bug in the calling
+  code, not something to render back as a validation error.
 
   ## Examples
 
@@ -229,6 +280,19 @@ defmodule Trogon.Ecto.BoundedString do
       iex> Trogon.Ecto.BoundedString.dump(nil, & &1, params)
       {:ok, nil}
 
+  An oversized value is refused, so a field written without casting cannot
+  escape the bound:
+
+      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
+      iex> Trogon.Ecto.BoundedString.dump("hello world", & &1, params)
+      :error
+
+  Under `truncate: true` it is cut instead, matching `cast/2`:
+
+      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5, truncate: true)
+      iex> Trogon.Ecto.BoundedString.dump("hello world", & &1, params)
+      {:ok, "hello"}
+
       iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
       iex> Trogon.Ecto.BoundedString.dump(123, & &1, params)
       :error
@@ -237,7 +301,14 @@ defmodule Trogon.Ecto.BoundedString do
   @spec dump(term(), (Ecto.Type.t(), term() -> {:ok, term()} | :error), params()) ::
           {:ok, String.t() | nil} | :error
   def dump(nil, _dumper, _params), do: {:ok, nil}
-  def dump(value, _dumper, _params) when is_binary(value), do: {:ok, value}
+
+  def dump(value, _dumper, %{max_length: max_length, truncate: truncate}) when is_binary(value) do
+    case apply_bound(value, max_length, truncate) do
+      {:ok, value} -> {:ok, value}
+      :too_long -> :error
+    end
+  end
+
   def dump(_value, _dumper, _params), do: :error
 
   @doc """

--- a/apps/trogon_ecto/lib/trogon/ecto/bounded_string.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/bounded_string.ex
@@ -1,18 +1,24 @@
 defmodule Trogon.Ecto.BoundedString do
+  alias Trogon.Ecto.FieldOptions
+
+  @own_keys [:max_length, :truncate]
+
   @opts_schema NimbleOptions.new!(
-                 max_length: [
-                   type: :pos_integer,
-                   required: true,
-                   doc: """
-                   Maximum length, counted in characters rather than bytes, so
-                   `max_length: 80` can outgrow a `varchar(80)` column.
-                   """
-                 ],
-                 truncate: [
-                   type: :boolean,
-                   default: false,
-                   doc: "Cut oversized values to fit instead of rejecting them."
-                 ]
+                 [
+                   max_length: [
+                     type: :pos_integer,
+                     required: true,
+                     doc: """
+                     Maximum length, counted in characters rather than bytes, so
+                     `max_length: 80` can outgrow a `varchar(80)` column.
+                     """
+                   ],
+                   truncate: [
+                     type: :boolean,
+                     default: false,
+                     doc: "Cut oversized values to fit instead of rejecting them."
+                   ]
+                 ] ++ FieldOptions.nimble_schema()
                )
 
   @moduledoc """
@@ -52,8 +58,8 @@ defmodule Trogon.Ecto.BoundedString do
   @spec init(keyword()) :: params()
   def init(opts) do
     opts
-    |> Keyword.take([:max_length, :truncate])
     |> NimbleOptions.validate!(@opts_schema)
+    |> Keyword.take(@own_keys)
     |> Map.new()
   end
 

--- a/apps/trogon_ecto/lib/trogon/ecto/bounded_string.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/bounded_string.ex
@@ -1,0 +1,256 @@
+defmodule Trogon.Ecto.BoundedString do
+  @moduledoc """
+  An `Ecto.ParameterizedType` for a string bounded to a maximum length, declared
+  at the field rather than restated in every changeset.
+
+      field :title, Trogon.Ecto.BoundedString, max_length: 80
+      field :error, Trogon.Ecto.BoundedString, max_length: 256, truncate: true
+
+  The bound travels with the field, so it holds for every write path into it,
+  including the ones that never call `Ecto.Changeset.validate_length/3`.
+
+  ## The `:max_length` option
+
+  Required, a positive integer. Counts graphemes, matching
+  `Ecto.Changeset.validate_length/3` and never splitting a character. The
+  serialized byte size of multi-byte text can exceed it, so this bounds order of
+  magnitude, not exact bytes; size a `varchar` column accordingly, or prefer
+  `text` and let the type be the bound.
+
+  ## The `:truncate` option
+
+  Decides what an oversized value means.
+
+  - `false` (the default) - an oversized value is a cast error, carrying the same
+    message and metadata (`count`, `validation: :length`, `kind: :max`,
+    `type: :string`) that `Ecto.Changeset.validate_length/3` would have produced,
+    so existing error traversal and translation keep working unchanged.
+  - `true` - the value is silently cut at the bound instead.
+
+  Reserve `truncate: true` for diagnostic text sourced from unbounded external
+  payloads (vendor HTTP bodies, gRPC status messages), where recording a lossy
+  detail beats failing the command that records it. For anything a user typed and
+  expects back verbatim, leave it off and let the cast fail.
+
+  Truncation happens on cast, so the shortened value is what the changeset holds
+  and what every later validation sees, not a surprise applied on the way to the
+  database.
+
+  ## Bounds are not enforced on load
+
+  `load/3` accepts any binary, whatever the bound. A column whose values predate
+  the bound, or predate a tightening of it, still reads cleanly; only new writes
+  are held to it. Tighten a bound when you are willing to have reads and writes
+  disagree until the existing rows are migrated.
+  """
+
+  use Ecto.ParameterizedType
+
+  @type params :: %{max_length: pos_integer(), truncate: boolean()}
+
+  @doc """
+  Initializes the parameterized type from the `:max_length` and `:truncate` options.
+
+  Ecto injects extra keys (`:field`, `:schema`) into `opts`; they are ignored.
+  Raises `ArgumentError` when `:max_length` is missing or is not a positive
+  integer, or when `:truncate` is not a boolean.
+
+  ## Examples
+
+      iex> Trogon.Ecto.BoundedString.init(max_length: 80)
+      %{max_length: 80, truncate: false}
+
+      iex> Trogon.Ecto.BoundedString.init(max_length: 256, truncate: true)
+      %{max_length: 256, truncate: true}
+
+      iex> Trogon.Ecto.BoundedString.init([])
+      ** (ArgumentError) missing :max_length for Trogon.Ecto.BoundedString, expected a positive integer
+
+      iex> Trogon.Ecto.BoundedString.init(max_length: 0)
+      ** (ArgumentError) invalid :max_length 0 for Trogon.Ecto.BoundedString, expected a positive integer
+
+      iex> Trogon.Ecto.BoundedString.init(max_length: 80, truncate: :yes)
+      ** (ArgumentError) invalid :truncate :yes for Trogon.Ecto.BoundedString, expected a boolean
+  """
+  @impl Ecto.ParameterizedType
+  @spec init(keyword()) :: params()
+  def init(opts) do
+    %{max_length: max_length!(opts), truncate: truncate!(opts)}
+  end
+
+  defp max_length!(opts) do
+    case Keyword.fetch(opts, :max_length) do
+      {:ok, max_length} ->
+        validate_max_length!(max_length)
+
+      :error ->
+        raise ArgumentError,
+              "missing :max_length for Trogon.Ecto.BoundedString, expected a positive integer"
+    end
+  end
+
+  defp validate_max_length!(max_length) when is_integer(max_length) and max_length > 0, do: max_length
+
+  defp validate_max_length!(other) do
+    raise ArgumentError,
+          "invalid :max_length #{inspect(other)} for Trogon.Ecto.BoundedString, " <>
+            "expected a positive integer"
+  end
+
+  defp truncate!(opts) do
+    opts
+    |> Keyword.get(:truncate, false)
+    |> validate_truncate!()
+  end
+
+  defp validate_truncate!(truncate) when is_boolean(truncate), do: truncate
+
+  defp validate_truncate!(other) do
+    raise ArgumentError,
+          "invalid :truncate #{inspect(other)} for Trogon.Ecto.BoundedString, " <>
+            "expected a boolean"
+  end
+
+  @doc """
+  Returns the underlying Ecto type used to persist the value, always `:string`.
+
+  ## Examples
+
+      iex> params = Trogon.Ecto.BoundedString.init(max_length: 80)
+      iex> Trogon.Ecto.BoundedString.type(params)
+      :string
+  """
+  @impl Ecto.ParameterizedType
+  @spec type(params()) :: :string
+  def type(_params), do: :string
+
+  @doc """
+  Casts a binary, holding it to the configured bound.
+
+  A value within the bound is returned as-is, and `nil` passes through. An
+  oversized value is cut at the bound under `truncate: true`, and otherwise
+  returns the `Ecto.Changeset.validate_length/3` error metadata for a `:max`
+  violation. Anything that is not a binary returns `:error`.
+
+  ## Examples
+
+      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
+      iex> Trogon.Ecto.BoundedString.cast("hello", params)
+      {:ok, "hello"}
+
+      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
+      iex> Trogon.Ecto.BoundedString.cast(nil, params)
+      {:ok, nil}
+
+      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
+      iex> Trogon.Ecto.BoundedString.cast("hello world", params)
+      {:error, [message: "should be at most %{count} character(s)", count: 5, validation: :length, kind: :max, type: :string]}
+
+      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5, truncate: true)
+      iex> Trogon.Ecto.BoundedString.cast("hello world", params)
+      {:ok, "hello"}
+
+  Graphemes are counted, and never split:
+
+      iex> params = Trogon.Ecto.BoundedString.init(max_length: 2, truncate: true)
+      iex> Trogon.Ecto.BoundedString.cast("héllo", params)
+      {:ok, "hé"}
+
+      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
+      iex> Trogon.Ecto.BoundedString.cast(:hello, params)
+      :error
+  """
+  @impl Ecto.ParameterizedType
+  @spec cast(term(), params()) :: {:ok, String.t() | nil} | {:error, keyword()} | :error
+  def cast(nil, _params), do: {:ok, nil}
+
+  def cast(value, %{max_length: max_length, truncate: truncate}) when is_binary(value) do
+    cond do
+      String.length(value) <= max_length -> {:ok, value}
+      truncate -> {:ok, String.slice(value, 0, max_length)}
+      true -> {:error, too_long_error(max_length)}
+    end
+  end
+
+  def cast(_value, _params), do: :error
+
+  defp too_long_error(max_length) do
+    [
+      message: "should be at most %{count} character(s)",
+      count: max_length,
+      validation: :length,
+      kind: :max,
+      type: :string
+    ]
+  end
+
+  @doc """
+  Loads a binary from the database, without holding it to the bound.
+
+  ## Examples
+
+      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
+      iex> Trogon.Ecto.BoundedString.load("hello", & &1, params)
+      {:ok, "hello"}
+
+      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
+      iex> Trogon.Ecto.BoundedString.load("a value stored before the bound", & &1, params)
+      {:ok, "a value stored before the bound"}
+
+      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
+      iex> Trogon.Ecto.BoundedString.load(nil, & &1, params)
+      {:ok, nil}
+
+      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
+      iex> Trogon.Ecto.BoundedString.load(123, & &1, params)
+      :error
+  """
+  @impl Ecto.ParameterizedType
+  @spec load(term(), (Ecto.Type.t(), term() -> {:ok, term()} | :error), params()) ::
+          {:ok, String.t() | nil} | :error
+  def load(nil, _loader, _params), do: {:ok, nil}
+  def load(value, _loader, _params) when is_binary(value), do: {:ok, value}
+  def load(_value, _loader, _params), do: :error
+
+  @doc """
+  Dumps a binary, strictly.
+
+  The bound was already applied on cast, so a value reaching here is either
+  within it or was loaded from a column that predates it; either way it is
+  persisted as it stands.
+
+  ## Examples
+
+      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
+      iex> Trogon.Ecto.BoundedString.dump("hello", & &1, params)
+      {:ok, "hello"}
+
+      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
+      iex> Trogon.Ecto.BoundedString.dump(nil, & &1, params)
+      {:ok, nil}
+
+      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
+      iex> Trogon.Ecto.BoundedString.dump(123, & &1, params)
+      :error
+  """
+  @impl Ecto.ParameterizedType
+  @spec dump(term(), (Ecto.Type.t(), term() -> {:ok, term()} | :error), params()) ::
+          {:ok, String.t() | nil} | :error
+  def dump(nil, _dumper, _params), do: {:ok, nil}
+  def dump(value, _dumper, _params) when is_binary(value), do: {:ok, value}
+  def dump(_value, _dumper, _params), do: :error
+
+  @doc """
+  Returns how the value is persisted when the type is used inside an embed,
+  always `:dump`.
+
+  ## Examples
+
+      iex> params = Trogon.Ecto.BoundedString.init(max_length: 5)
+      iex> Trogon.Ecto.BoundedString.embed_as(:json, params)
+      :dump
+  """
+  @impl Ecto.ParameterizedType
+  @spec embed_as(atom(), params()) :: :dump
+  def embed_as(_format, _params), do: :dump
+end

--- a/apps/trogon_ecto/lib/trogon/ecto/field_options.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/field_options.ex
@@ -1,0 +1,33 @@
+defmodule Trogon.Ecto.FieldOptions do
+  @moduledoc false
+
+  # The options `Ecto.Schema.field/3` documents, which Ecto passes straight
+  # through to `Ecto.ParameterizedType.init/1` without checking them, plus the
+  # two keys it injects there itself. Kept in one place so a parameterized type
+  # can reject a misspelled option of its own without rejecting these.
+  #
+  # Sourced from the `field/3` @doc in `Ecto.Schema`, not from its private
+  # `@field_opts` attribute: that one is shared with the association macros and
+  # so also lists options a field has no use for.
+  @ecto_keys [
+    :default,
+    :source,
+    :autogenerate,
+    :read_after_writes,
+    :virtual,
+    :primary_key,
+    :load_in_query,
+    :redact,
+    :skip_default_validation,
+    :writable,
+    :on_writable_violation
+  ]
+
+  @injected_keys [:field, :schema]
+
+  @spec keys() :: [atom()]
+  def keys, do: @ecto_keys ++ @injected_keys
+
+  @spec nimble_schema() :: keyword()
+  def nimble_schema, do: Enum.map(keys(), &{&1, [type: :any, doc: false]})
+end

--- a/apps/trogon_ecto/mix.exs
+++ b/apps/trogon_ecto/mix.exs
@@ -41,6 +41,7 @@ defmodule Trogon.Ecto.MixProject do
   defp deps do
     [
       {:ecto, "~> 3.12"},
+      {:nimble_options, "~> 1.0"},
       {:ecto_sql, "~> 3.12", optional: true},
       {:postgrex, "~> 0.19 or ~> 1.0", optional: true},
       {:polymorphic_embed, "~> 5.0"},

--- a/apps/trogon_ecto/test/support/test_support.ex
+++ b/apps/trogon_ecto/test/support/test_support.ex
@@ -293,6 +293,24 @@ defmodule Trogon.Ecto.TestSupport do
     use Trogon.Ecto.Enum, values: [true, false]
   end
 
+  defmodule WithBoundedString do
+    @moduledoc false
+    use Trogon.Ecto.ValueObject
+
+    embedded_schema do
+      field :title, Trogon.Ecto.BoundedString, max_length: 5
+    end
+  end
+
+  defmodule WithTruncatedBoundedString do
+    @moduledoc false
+    use Trogon.Ecto.ValueObject
+
+    embedded_schema do
+      field :title, Trogon.Ecto.BoundedString, max_length: 5, truncate: true
+    end
+  end
+
   def errors_on(changeset) do
     PolymorphicEmbed.traverse_errors(changeset, fn {message, opts} ->
       Regex.replace(~r"%{(\w+)}", message, fn _, key ->

--- a/apps/trogon_ecto/test/trogon/ecto/bounded_string_test.exs
+++ b/apps/trogon_ecto/test/trogon/ecto/bounded_string_test.exs
@@ -9,34 +9,32 @@ defmodule Trogon.Ecto.BoundedStringTest do
   doctest BoundedString
 
   describe "init/1" do
-    test "raises ArgumentError when :max_length is missing" do
-      assert_raise ArgumentError, ~r/missing :max_length/, fn ->
+    test "raises when :max_length is missing" do
+      assert_raise NimbleOptions.ValidationError, ~r/required :max_length option not found/, fn ->
         BoundedString.init([])
       end
     end
 
-    test "raises ArgumentError for a non-positive :max_length" do
-      assert_raise ArgumentError, ~r/invalid :max_length 0/, fn ->
-        BoundedString.init(max_length: 0)
-      end
-
-      assert_raise ArgumentError, ~r/invalid :max_length -1/, fn ->
-        BoundedString.init(max_length: -1)
+    test "raises for a non-positive :max_length" do
+      for max_length <- [0, -1] do
+        assert_raise NimbleOptions.ValidationError,
+                     ~r/invalid value for :max_length option: expected positive integer/,
+                     fn -> BoundedString.init(max_length: max_length) end
       end
     end
 
-    test "raises ArgumentError for a non-integer :max_length" do
+    test "raises for a non-integer :max_length" do
       for max_length <- ["80", 80.0, nil, :eighty] do
-        assert_raise ArgumentError, ~r/invalid :max_length/, fn ->
-          BoundedString.init(max_length: max_length)
-        end
+        assert_raise NimbleOptions.ValidationError,
+                     ~r/invalid value for :max_length option: expected positive integer/,
+                     fn -> BoundedString.init(max_length: max_length) end
       end
     end
 
-    test "raises ArgumentError for a non-boolean :truncate" do
-      assert_raise ArgumentError, ~r/invalid :truncate :yes/, fn ->
-        BoundedString.init(max_length: 80, truncate: :yes)
-      end
+    test "raises for a non-boolean :truncate" do
+      assert_raise NimbleOptions.ValidationError,
+                   ~r/invalid value for :truncate option: expected boolean/,
+                   fn -> BoundedString.init(max_length: 80, truncate: :yes) end
     end
 
     test "defaults :truncate to false" do

--- a/apps/trogon_ecto/test/trogon/ecto/bounded_string_test.exs
+++ b/apps/trogon_ecto/test/trogon/ecto/bounded_string_test.exs
@@ -45,39 +45,6 @@ defmodule Trogon.Ecto.BoundedStringTest do
       assert BoundedString.init(max_length: 80, field: :title, schema: WithBoundedString) ==
                %{max_length: 80, truncate: false}
     end
-
-    test "ignores every option Ecto's own field/3 accepts" do
-      ecto_field_opts = [
-        default: "x",
-        source: :the_title,
-        autogenerate: false,
-        read_after_writes: false,
-        virtual: false,
-        primary_key: false,
-        load_in_query: true,
-        redact: true,
-        foreign_key: :id,
-        on_replace: :raise,
-        defaults: [],
-        type: :string,
-        where: [],
-        references: :id,
-        skip_default_validation: true,
-        writable: :always,
-        on_writable_violation: :raise
-      ]
-
-      assert BoundedString.init([max_length: 80] ++ ecto_field_opts) ==
-               %{max_length: 80, truncate: false}
-    end
-
-    test "raises for an unknown option" do
-      for opts <- [[max_length: 80, bogus: 1], [max_length: 80, truncat: true], [max_lenght: 80]] do
-        assert_raise NimbleOptions.ValidationError, ~r/unknown options \[:[a-z_]+\]/, fn ->
-          BoundedString.init(opts)
-        end
-      end
-    end
   end
 
   describe "type/1" do

--- a/apps/trogon_ecto/test/trogon/ecto/bounded_string_test.exs
+++ b/apps/trogon_ecto/test/trogon/ecto/bounded_string_test.exs
@@ -45,6 +45,39 @@ defmodule Trogon.Ecto.BoundedStringTest do
       assert BoundedString.init(max_length: 80, field: :title, schema: WithBoundedString) ==
                %{max_length: 80, truncate: false}
     end
+
+    test "ignores every option Ecto's own field/3 accepts" do
+      ecto_field_opts = [
+        default: "x",
+        source: :the_title,
+        autogenerate: false,
+        read_after_writes: false,
+        virtual: false,
+        primary_key: false,
+        load_in_query: true,
+        redact: true,
+        foreign_key: :id,
+        on_replace: :raise,
+        defaults: [],
+        type: :string,
+        where: [],
+        references: :id,
+        skip_default_validation: true,
+        writable: :always,
+        on_writable_violation: :raise
+      ]
+
+      assert BoundedString.init([max_length: 80] ++ ecto_field_opts) ==
+               %{max_length: 80, truncate: false}
+    end
+
+    test "raises for an unknown option" do
+      for opts <- [[max_length: 80, bogus: 1], [max_length: 80, truncat: true], [max_lenght: 80]] do
+        assert_raise NimbleOptions.ValidationError, ~r/unknown options \[:[a-z_]+\]/, fn ->
+          BoundedString.init(opts)
+        end
+      end
+    end
   end
 
   describe "type/1" do

--- a/apps/trogon_ecto/test/trogon/ecto/bounded_string_test.exs
+++ b/apps/trogon_ecto/test/trogon/ecto/bounded_string_test.exs
@@ -45,6 +45,35 @@ defmodule Trogon.Ecto.BoundedStringTest do
       assert BoundedString.init(max_length: 80, field: :title, schema: WithBoundedString) ==
                %{max_length: 80, truncate: false}
     end
+
+    test "ignores every option Ecto's field/3 documents" do
+      ecto_field_opts = [
+        default: "x",
+        source: :the_title,
+        autogenerate: false,
+        read_after_writes: false,
+        virtual: false,
+        primary_key: false,
+        load_in_query: true,
+        redact: true,
+        skip_default_validation: true,
+        writable: :always,
+        on_writable_violation: :raise
+      ]
+
+      assert Keyword.keys(ecto_field_opts) -- Trogon.Ecto.FieldOptions.keys() == []
+
+      assert BoundedString.init([max_length: 80] ++ ecto_field_opts) ==
+               %{max_length: 80, truncate: false}
+    end
+
+    test "raises for an unknown option" do
+      for opts <- [[max_length: 80, bogus: 1], [max_length: 80, truncat: true], [max_lenght: 80]] do
+        assert_raise NimbleOptions.ValidationError, ~r/unknown options \[:[a-z_]+\]/, fn ->
+          BoundedString.init(opts)
+        end
+      end
+    end
   end
 
   describe "type/1" do

--- a/apps/trogon_ecto/test/trogon/ecto/bounded_string_test.exs
+++ b/apps/trogon_ecto/test/trogon/ecto/bounded_string_test.exs
@@ -242,6 +242,14 @@ defmodule Trogon.Ecto.BoundedStringTest do
   end
 
   describe "embed_as/2" do
+    test "is :dump for every format" do
+      params = BoundedString.init(max_length: 5)
+
+      for format <- [:json, :self] do
+        assert BoundedString.embed_as(format, params) == :dump
+      end
+    end
+
     test "a nested bounded string is dumped as a plain string" do
       value_object = struct!(WithBoundedString, title: "hello")
 

--- a/apps/trogon_ecto/test/trogon/ecto/bounded_string_test.exs
+++ b/apps/trogon_ecto/test/trogon/ecto/bounded_string_test.exs
@@ -174,6 +174,31 @@ defmodule Trogon.Ecto.BoundedStringTest do
     test "rejects a non-binary value", %{params: params} do
       assert BoundedString.dump(123, & &1, params) == :error
     end
+
+    test "rejects an oversized value that never went through cast/2", %{params: params} do
+      assert BoundedString.dump("hello world", & &1, params) == :error
+    end
+
+    test "truncates an oversized value under `truncate: true`" do
+      params = BoundedString.init(max_length: 5, truncate: true)
+
+      assert BoundedString.dump("hello world", & &1, params) == {:ok, "hello"}
+    end
+
+    test "refuses to write back a legacy value that load/3 accepted", %{params: params} do
+      legacy = "a value stored before the bound"
+
+      assert BoundedString.load(legacy, & &1, params) == {:ok, legacy}
+      assert BoundedString.dump(legacy, & &1, params) == :error
+    end
+
+    test "a legacy value is truncated on write back under `truncate: true`" do
+      params = BoundedString.init(max_length: 5, truncate: true)
+      legacy = "a value stored before the bound"
+
+      assert BoundedString.load(legacy, & &1, params) == {:ok, legacy}
+      assert BoundedString.dump(legacy, & &1, params) == {:ok, "a val"}
+    end
   end
 
   describe "round trip" do
@@ -203,6 +228,17 @@ defmodule Trogon.Ecto.BoundedStringTest do
       assert {:ok, %WithTruncatedBoundedString{title: "hello"}} =
                WithTruncatedBoundedString.new(%{title: "hello world"})
     end
+
+    test "the changeset error keeps the length metadata but replaces `:type`" do
+      assert {:error, %Ecto.Changeset{errors: [title: {_message, metadata}]}} =
+               WithBoundedString.new(%{title: "hello world"})
+
+      assert Keyword.take(metadata, [:count, :validation, :kind]) ==
+               [count: 5, validation: :length, kind: :max]
+
+      assert Keyword.fetch!(metadata, :type) ==
+               {:parameterized, {BoundedString, %{max_length: 5, truncate: false}}}
+    end
   end
 
   describe "embed_as/2" do
@@ -223,6 +259,14 @@ defmodule Trogon.Ecto.BoundedStringTest do
       value_object = struct!(WithBoundedString, title: nil)
 
       assert {:ok, %{title: nil}} = WithBoundedString.dump(value_object)
+    end
+
+    test "an oversized value built with struct!/2 cannot be dumped" do
+      value_object = struct!(WithBoundedString, title: "hello world")
+
+      assert_raise ArgumentError, ~r/cannot dump `"hello world"`/, fn ->
+        WithBoundedString.dump(value_object)
+      end
     end
   end
 end

--- a/apps/trogon_ecto/test/trogon/ecto/bounded_string_test.exs
+++ b/apps/trogon_ecto/test/trogon/ecto/bounded_string_test.exs
@@ -1,0 +1,228 @@
+defmodule Trogon.Ecto.BoundedStringTest do
+  use ExUnit.Case, async: true
+
+  alias Trogon.Ecto.BoundedString
+  alias Trogon.Ecto.TestSupport
+  alias Trogon.Ecto.TestSupport.WithBoundedString
+  alias Trogon.Ecto.TestSupport.WithTruncatedBoundedString
+
+  doctest BoundedString
+
+  describe "init/1" do
+    test "raises ArgumentError when :max_length is missing" do
+      assert_raise ArgumentError, ~r/missing :max_length/, fn ->
+        BoundedString.init([])
+      end
+    end
+
+    test "raises ArgumentError for a non-positive :max_length" do
+      assert_raise ArgumentError, ~r/invalid :max_length 0/, fn ->
+        BoundedString.init(max_length: 0)
+      end
+
+      assert_raise ArgumentError, ~r/invalid :max_length -1/, fn ->
+        BoundedString.init(max_length: -1)
+      end
+    end
+
+    test "raises ArgumentError for a non-integer :max_length" do
+      for max_length <- ["80", 80.0, nil, :eighty] do
+        assert_raise ArgumentError, ~r/invalid :max_length/, fn ->
+          BoundedString.init(max_length: max_length)
+        end
+      end
+    end
+
+    test "raises ArgumentError for a non-boolean :truncate" do
+      assert_raise ArgumentError, ~r/invalid :truncate :yes/, fn ->
+        BoundedString.init(max_length: 80, truncate: :yes)
+      end
+    end
+
+    test "defaults :truncate to false" do
+      assert BoundedString.init(max_length: 80) == %{max_length: 80, truncate: false}
+    end
+
+    test "ignores the keys Ecto injects" do
+      assert BoundedString.init(max_length: 80, field: :title, schema: WithBoundedString) ==
+               %{max_length: 80, truncate: false}
+    end
+  end
+
+  describe "type/1" do
+    test "is :string" do
+      assert BoundedString.type(BoundedString.init(max_length: 80)) == :string
+    end
+  end
+
+  describe "cast/2" do
+    setup do
+      %{params: BoundedString.init(max_length: 5)}
+    end
+
+    test "accepts a value within the bound", %{params: params} do
+      assert BoundedString.cast("hello", params) == {:ok, "hello"}
+    end
+
+    test "accepts a value exactly at the bound", %{params: params} do
+      assert BoundedString.cast("12345", params) == {:ok, "12345"}
+    end
+
+    test "accepts an empty string", %{params: params} do
+      assert BoundedString.cast("", params) == {:ok, ""}
+    end
+
+    test "accepts nil", %{params: params} do
+      assert BoundedString.cast(nil, params) == {:ok, nil}
+    end
+
+    test "rejects an oversized value with validate_length/3 error metadata", %{params: params} do
+      assert BoundedString.cast("hello world", params) ==
+               {:error,
+                [
+                  message: "should be at most %{count} character(s)",
+                  count: 5,
+                  validation: :length,
+                  kind: :max,
+                  type: :string
+                ]}
+    end
+
+    test "rejects a value of an unsupported type", %{params: params} do
+      for value <- [123, 1.5, :hello, [], %{}, true, ["hello"]] do
+        assert BoundedString.cast(value, params) == :error
+      end
+    end
+
+    test "counts graphemes rather than bytes" do
+      params = BoundedString.init(max_length: 5)
+
+      assert BoundedString.cast("héllo", params) == {:ok, "héllo"}
+      assert byte_size("héllo") > 5
+    end
+
+    test "counts a combined grapheme as one character" do
+      params = BoundedString.init(max_length: 1)
+
+      assert BoundedString.cast("é", params) == {:ok, "é"}
+    end
+  end
+
+  describe "cast/2 with truncate: true" do
+    setup do
+      %{params: BoundedString.init(max_length: 5, truncate: true)}
+    end
+
+    test "cuts an oversized value at the bound", %{params: params} do
+      assert BoundedString.cast("hello world", params) == {:ok, "hello"}
+    end
+
+    test "leaves a value within the bound untouched", %{params: params} do
+      assert BoundedString.cast("hey", params) == {:ok, "hey"}
+    end
+
+    test "never splits a grapheme" do
+      params = BoundedString.init(max_length: 2, truncate: true)
+
+      assert BoundedString.cast("héllo", params) == {:ok, "hé"}
+    end
+
+    test "passes nil through", %{params: params} do
+      assert BoundedString.cast(nil, params) == {:ok, nil}
+    end
+
+    test "still rejects a value of an unsupported type", %{params: params} do
+      assert BoundedString.cast(123, params) == :error
+    end
+  end
+
+  describe "load/3" do
+    setup do
+      %{params: BoundedString.init(max_length: 5)}
+    end
+
+    test "loads a binary as-is", %{params: params} do
+      assert BoundedString.load("hello", & &1, params) == {:ok, "hello"}
+    end
+
+    test "loads a value that predates the bound", %{params: params} do
+      assert BoundedString.load("hello world", & &1, params) == {:ok, "hello world"}
+    end
+
+    test "loads nil as nil", %{params: params} do
+      assert BoundedString.load(nil, & &1, params) == {:ok, nil}
+    end
+
+    test "rejects a non-binary value", %{params: params} do
+      assert BoundedString.load(123, & &1, params) == :error
+    end
+  end
+
+  describe "dump/3" do
+    setup do
+      %{params: BoundedString.init(max_length: 5)}
+    end
+
+    test "dumps a binary as-is", %{params: params} do
+      assert BoundedString.dump("hello", & &1, params) == {:ok, "hello"}
+    end
+
+    test "dumps nil as nil", %{params: params} do
+      assert BoundedString.dump(nil, & &1, params) == {:ok, nil}
+    end
+
+    test "rejects a non-binary value", %{params: params} do
+      assert BoundedString.dump(123, & &1, params) == :error
+    end
+  end
+
+  describe "round trip" do
+    test "a cast value round-trips exactly" do
+      params = BoundedString.init(max_length: 5)
+
+      for value <- ["hello", "héllo", "", "12345"] do
+        assert {:ok, cast} = BoundedString.cast(value, params)
+        assert {:ok, dumped} = BoundedString.dump(cast, & &1, params)
+        assert {:ok, ^cast} = BoundedString.load(dumped, & &1, params)
+      end
+    end
+  end
+
+  describe "schema field declarations" do
+    test "the bound is enforced without any changeset validation" do
+      assert {:error, changeset} = WithBoundedString.new(%{title: "hello world"})
+
+      assert TestSupport.errors_on(changeset) == %{title: ["should be at most 5 character(s)"]}
+    end
+
+    test "a value within the bound is accepted" do
+      assert {:ok, %WithBoundedString{title: "hello"}} = WithBoundedString.new(%{title: "hello"})
+    end
+
+    test "`truncate: true` cuts the value the changeset ends up holding" do
+      assert {:ok, %WithTruncatedBoundedString{title: "hello"}} =
+               WithTruncatedBoundedString.new(%{title: "hello world"})
+    end
+  end
+
+  describe "embed_as/2" do
+    test "a nested bounded string is dumped as a plain string" do
+      value_object = struct!(WithBoundedString, title: "hello")
+
+      assert {:ok, %{title: "hello"}} = WithBoundedString.dump(value_object)
+    end
+
+    test "the dumped value object is JSON encodable" do
+      value_object = struct!(WithBoundedString, title: "hello")
+      {:ok, dumped} = WithBoundedString.dump(value_object)
+
+      assert {:ok, ~s({"title":"hello"})} = Jason.encode(dumped)
+    end
+
+    test "a nil value survives the round trip" do
+      value_object = struct!(WithBoundedString, title: nil)
+
+      assert {:ok, %{title: nil}} = WithBoundedString.dump(value_object)
+    end
+  end
+end

--- a/apps/trogon_ecto/test/trogon/ecto/field_options_test.exs
+++ b/apps/trogon_ecto/test/trogon/ecto/field_options_test.exs
@@ -1,0 +1,71 @@
+defmodule Trogon.Ecto.FieldOptionsTest do
+  use ExUnit.Case, async: true
+
+  alias Trogon.Ecto.FieldOptions
+
+  describe "keys/0" do
+    test "is every option Ecto's field/3 documents, plus the two Ecto injects" do
+      assert FieldOptions.keys() == [
+               :default,
+               :source,
+               :autogenerate,
+               :read_after_writes,
+               :virtual,
+               :primary_key,
+               :load_in_query,
+               :redact,
+               :skip_default_validation,
+               :writable,
+               :on_writable_violation,
+               :field,
+               :schema
+             ]
+    end
+
+    test "every key is one Ecto's own field/3 accepts" do
+      for {key, value} <- [
+            default: "x",
+            source: :aa,
+            autogenerate: false,
+            read_after_writes: false,
+            virtual: false,
+            primary_key: false,
+            load_in_query: true,
+            redact: true,
+            skip_default_validation: true,
+            writable: :always,
+            on_writable_violation: :raise
+          ] do
+        assert key in FieldOptions.keys()
+
+        defmodule_with_field = """
+        defmodule EctoAccepts#{key} do
+          use Ecto.Schema
+          @primary_key false
+          embedded_schema do
+            field :a, :string, #{key}: #{inspect(value)}
+          end
+        end
+        """
+
+        assert [_ | _] = Code.compile_string(defmodule_with_field)
+      end
+    end
+
+    test "excludes the association options Ecto's private @field_opts also lists" do
+      for key <- [:foreign_key, :on_replace, :defaults, :type, :where, :references] do
+        refute key in FieldOptions.keys()
+      end
+    end
+  end
+
+  describe "nimble_schema/0" do
+    test "accepts any value and stays out of the generated docs" do
+      schema = FieldOptions.nimble_schema()
+
+      assert Keyword.keys(schema) == FieldOptions.keys()
+      assert Enum.all?(schema, fn {_key, spec} -> spec == [type: :any, doc: false] end)
+      assert NimbleOptions.docs(NimbleOptions.new!(schema)) == ""
+    end
+  end
+end


### PR DESCRIPTION
- Length bounds on string fields kept being restated in every changeset that touched them, so a write path that skipped the validation quietly stored oversized text; declaring the bound on the field makes it hold for every path into that field.
- Diagnostic text copied from unbounded external payloads (vendor HTTP bodies, gRPC status messages) was failing the very command meant to record it; `truncate: true` makes the lossy-but-recorded outcome an explicit, per-field decision rather than an ad hoc slice at each call site.
- Reuses the error metadata `Ecto.Changeset.validate_length/3` produces, so error traversal and translation already in place keep working unchanged.
- Bounds are enforced on cast but not on load, so a bound can be introduced or tightened without existing rows becoming unreadable.