### PR TITLE
refactor(trogon_ecto): share changeset error message interpolation

### DIFF
--- a/apps/trogon_ecto/lib/trogon/ecto/error_message.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/error_message.ex
@@ -1,0 +1,25 @@
+defmodule Trogon.Ecto.ErrorMessage do
+  @moduledoc false
+
+  @spec interpolate({String.t(), keyword()}) :: String.t()
+  def interpolate({message, opts}) do
+    Enum.reduce(opts, message, &replace_binding/2)
+  end
+
+  defp replace_binding({key, value}, message) do
+    placeholder = placeholder(key)
+
+    if String.contains?(message, placeholder) do
+      String.replace(message, placeholder, stringify(value))
+    else
+      message
+    end
+  end
+
+  defp placeholder(key), do: "%{#{key}}"
+
+  defp stringify(value) when is_binary(value), do: value
+  defp stringify(value) when is_number(value), do: to_string(value)
+  defp stringify(value) when is_atom(value) and not is_nil(value), do: to_string(value)
+  defp stringify(value), do: inspect(value)
+end

--- a/apps/trogon_ecto/lib/trogon/ecto/value_object.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/value_object.ex
@@ -4,6 +4,7 @@ defmodule Trogon.Ecto.ValueObject do
   """
 
   alias Ecto.Changeset
+  alias Trogon.Ecto.ErrorMessage
 
   @doc """
   Converts the module into an `Ecto.Schema` and add factory functions to create structs.
@@ -531,7 +532,7 @@ defmodule Trogon.Ecto.ValueObject do
 
   defp describe_errors(changeset) do
     changeset
-    |> PolymorphicEmbed.traverse_errors(&interpolate_message/1)
+    |> PolymorphicEmbed.traverse_errors(&ErrorMessage.interpolate/1)
     |> flatten_errors("")
     |> Enum.join(", ")
   end
@@ -560,18 +561,6 @@ defmodule Trogon.Ecto.ValueObject do
 
   defp join_path("", segment), do: segment
   defp join_path(path, segment), do: path <> "." <> segment
-
-  defp interpolate_message({message, opts}) do
-    Enum.reduce(opts, message, &replace_binding/2)
-  end
-
-  defp replace_binding({key, value}, message) do
-    String.replace(message, "%{#{key}}", stringify(value))
-  end
-
-  defp stringify(value) when is_binary(value), do: value
-  defp stringify(value) when is_atom(value) or is_number(value), do: to_string(value)
-  defp stringify(value), do: inspect(value)
 
   defp apply_changeset(struct_module, attrs) do
     struct(struct_module)

--- a/apps/trogon_ecto/test/trogon/ecto/error_message_test.exs
+++ b/apps/trogon_ecto/test/trogon/ecto/error_message_test.exs
@@ -1,0 +1,71 @@
+defmodule Trogon.Ecto.ErrorMessageTest do
+  use ExUnit.Case, async: true
+
+  alias Trogon.Ecto.ErrorMessage
+
+  describe "interpolate/1" do
+    test "returns a message with no placeholders unchanged" do
+      assert ErrorMessage.interpolate({"can't be blank", []}) == "can't be blank"
+    end
+
+    test "replaces a placeholder with its binding" do
+      assert ErrorMessage.interpolate({"should be at most %{count} character(s)", [count: 5]}) ==
+               "should be at most 5 character(s)"
+    end
+
+    test "replaces every placeholder in the message" do
+      assert ErrorMessage.interpolate({"%{count} of %{kind}", [count: 2, kind: :list]}) ==
+               "2 of list"
+    end
+
+    test "replaces every occurrence of the same placeholder" do
+      assert ErrorMessage.interpolate({"%{val} and %{val}", [val: "x"]}) == "x and x"
+    end
+
+    test "leaves a placeholder with no binding alone" do
+      assert ErrorMessage.interpolate({"got %{value}", []}) == "got %{value}"
+    end
+
+    test "leaves a placeholder alone when a different key is bound" do
+      assert ErrorMessage.interpolate({"got %{value}", [count: 5]}) == "got %{value}"
+    end
+
+    test "keeps a string binding as it is" do
+      assert ErrorMessage.interpolate({"got %{value}", [value: "hello"]}) == "got hello"
+    end
+
+    test "writes a number binding the way it is written in Elixir" do
+      assert ErrorMessage.interpolate({"got %{value}", [value: 5]}) == "got 5"
+      assert ErrorMessage.interpolate({"got %{value}", [value: -1]}) == "got -1"
+      assert ErrorMessage.interpolate({"got %{value}", [value: 1.5]}) == "got 1.5"
+    end
+
+    test "writes an atom binding without its colon" do
+      assert ErrorMessage.interpolate({"got %{value}", [value: :max]}) == "got max"
+    end
+
+    test "inspects a binding that has no string form" do
+      for {value, expected} <- [
+            {[1, 2], "got [1, 2]"},
+            {{:a, :b}, "got {:a, :b}"},
+            {%{a: 1}, "got %{a: 1}"},
+            {nil, "got nil"},
+            {["a", "b"], ~s(got ["a", "b"])}
+          ] do
+        assert ErrorMessage.interpolate({"got %{value}", [value: value]}) == expected
+      end
+    end
+
+    test "inspects a struct binding rather than raising" do
+      assert ErrorMessage.interpolate({"got %{value}", [value: ~D[2024-01-01]]}) ==
+               "got ~D[2024-01-01]"
+    end
+
+    test "renders the metadata Ecto attaches to a parameterized cast error" do
+      type = {:parameterized, {Trogon.Ecto.BoundedString, %{max_length: 5, truncate: false}}}
+
+      assert ErrorMessage.interpolate({"is invalid", [type: type, validation: :cast]}) ==
+               "is invalid"
+    end
+  end
+end


### PR DESCRIPTION
- Rendering an `Ecto.Changeset` error message is about to be needed by more than the value object, and a second copy of that logic means the same error renders differently depending on which path reported it.
- The existing copy raises on a binding that has no string form, which is reachable from any custom validation, so it should be fixed once rather than per caller.
- It also rendered a `nil` binding as nothing at all, so a message came out as `"got "`. A reader cannot tell that from a message whose binding was an empty string, and the distinction is the whole point of reporting the value back.
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
