### PR TITLE
feat(trogon_ecto): report changeset errors as field violations

### DIFF
--- a/apps/trogon_ecto/lib/trogon/ecto/changeset.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/changeset.ex
@@ -1,6 +1,7 @@
 defmodule Trogon.Ecto.Changeset do
   @moduledoc """
-  Extends `Ecto.Changeset` with validations for conventions shared across changesets.
+  Extends `Ecto.Changeset` with validations for conventions shared across
+  changesets, and turns a failed changeset into data an API layer can report.
 
       import Trogon.Ecto.Changeset
 
@@ -12,6 +13,10 @@ defmodule Trogon.Ecto.Changeset do
   """
 
   alias Ecto.Changeset
+  alias Trogon.Ecto.ErrorMessage
+  alias Trogon.Ecto.FieldViolation
+
+  @derived_metadata_keys [:validation, :constraint, :kind, :code, :type]
 
   @doc """
   Validates that a field is unset, the exact opposite of `Ecto.Changeset.validate_required/3`.
@@ -58,4 +63,150 @@ defmodule Trogon.Ecto.Changeset do
   end
 
   defp message(opts), do: Keyword.get(opts, :message, "must be blank")
+
+  @doc """
+  Flattens every error in a changeset, however deeply nested, into a list of
+  `Trogon.Ecto.FieldViolation`.
+
+  This is the shape an API layer needs and a changeset will not give you: one
+  entry per error, each naming the field it is about with a path a caller can
+  follow, a machine readable reason to branch on, a message already interpolated
+  so nothing downstream has to know about `%{count}`, and that same message
+  before interpolation together with its bindings, for a caller that would rather
+  render it itself.
+
+  Embeds, associations, and `PolymorphicEmbed` fields are all traversed. Members
+  of a collection are indexed, so a failure two levels down reads `"items[0].sku"`.
+
+  A member being replaced is dropped before anything is indexed. Ecto keeps those
+  on the front of the collection it traverses, so an index taken straight from a
+  changeset counts values that are on their way out and points the caller at the
+  wrong member of the list they sent.
+
+  Violations are sorted by field path, so equivalent changesets produce byte for
+  byte equivalent output. Errors on the same field keep their relative order.
+
+  See `Trogon.Ecto.FieldViolation` for how a reason is derived.
+
+  ## Examples
+
+      iex> types = %{name: :string}
+      iex> changeset = Ecto.Changeset.cast({%{name: nil}, types}, %{}, Map.keys(types))
+      iex> changeset = Ecto.Changeset.validate_required(changeset, [:name])
+      iex> Trogon.Ecto.Changeset.field_violations(changeset)
+      [
+        %Trogon.Ecto.FieldViolation{
+          field: "name",
+          reason: :required,
+          message: "can't be blank",
+          template: "can't be blank",
+          metadata: []
+        }
+      ]
+
+      iex> types = %{title: :string}
+      iex> changeset = Ecto.Changeset.cast({%{title: nil}, types}, %{title: "too long"}, Map.keys(types))
+      iex> changeset = Ecto.Changeset.validate_length(changeset, :title, max: 3)
+      iex> Trogon.Ecto.Changeset.field_violations(changeset)
+      [
+        %Trogon.Ecto.FieldViolation{
+          field: "title",
+          reason: :max_length,
+          message: "should be at most 3 character(s)",
+          template: "should be at most %{count} character(s)",
+          metadata: [count: 3]
+        }
+      ]
+
+      iex> types = %{age: :integer}
+      iex> changeset = Ecto.Changeset.cast({%{age: nil}, types}, %{age: "old"}, Map.keys(types))
+      iex> [violation] = Trogon.Ecto.Changeset.field_violations(changeset)
+      iex> {violation.reason, violation.template, violation.metadata}
+      {:cast, "is invalid", []}
+  """
+  @spec field_violations(Changeset.t()) :: [FieldViolation.t()]
+  def field_violations(%Changeset{} = changeset) do
+    changeset
+    |> reject_replaced_changes()
+    |> PolymorphicEmbed.traverse_errors(&to_violation_parts/1)
+    |> to_field_violations("")
+    |> Enum.sort_by(& &1.field)
+  end
+
+  defp reject_replaced_changes(values) when is_list(values) do
+    values
+    |> Enum.map(&reject_replaced_changes/1)
+    |> Enum.reject(&match?(%Changeset{action: :replace}, &1))
+  end
+
+  defp reject_replaced_changes(%Changeset{} = changeset) do
+    %{changeset | changes: Map.new(changeset.changes, &reject_replaced_change/1)}
+  end
+
+  defp reject_replaced_changes(value), do: value
+
+  defp reject_replaced_change({key, value}), do: {key, reject_replaced_changes(value)}
+
+  defp to_violation_parts({template, opts}) do
+    {ErrorMessage.interpolate({template, opts}), template, reason(Map.new(opts)), to_metadata(template, opts)}
+  end
+
+  defp to_metadata(template, opts) do
+    Enum.reject(opts, fn {key, _value} ->
+      key in @derived_metadata_keys and not ErrorMessage.interpolates?(template, key)
+    end)
+  end
+
+  defp reason(%{code: code}) when is_atom(code), do: code
+  defp reason(%{validation: :length, kind: :min}), do: :min_length
+  defp reason(%{validation: :length, kind: :max}), do: :max_length
+  defp reason(%{validation: :length}), do: :length
+  defp reason(%{validation: :number, kind: kind}), do: kind
+  defp reason(%{validation: validation}), do: validation
+  defp reason(%{constraint: :unique}), do: :unique_constraint
+  defp reason(%{constraint: :foreign}), do: :foreign_constraint
+  defp reason(%{constraint: :assoc}), do: :assoc_constraint
+  defp reason(%{constraint: :no_assoc}), do: :no_assoc_constraint
+  defp reason(%{constraint: :check}), do: :check_constraint
+  defp reason(%{constraint: :exclusion}), do: :exclusion_constraint
+  defp reason(%{constraint: _constraint}), do: :constraint
+  defp reason(_opts), do: :unknown
+
+  defp to_field_violations(errors, path) do
+    Enum.flat_map(errors, &field_to_violations(&1, path))
+  end
+
+  defp field_to_violations({field, value}, path) do
+    field_path = join_field_path(path, field)
+
+    case value do
+      parts when is_list(parts) ->
+        parts
+        |> Enum.with_index()
+        |> Enum.flat_map(&indexed_to_violations(&1, field_path))
+
+      nested when is_map(nested) ->
+        to_field_violations(nested, field_path)
+    end
+  end
+
+  defp indexed_to_violations({{message, template, reason, metadata}, _index}, field_path)
+       when is_binary(message) do
+    [
+      %FieldViolation{
+        field: field_path,
+        reason: reason,
+        message: message,
+        template: template,
+        metadata: metadata
+      }
+    ]
+  end
+
+  defp indexed_to_violations({nested, index}, field_path) do
+    to_field_violations(nested, "#{field_path}[#{index}]")
+  end
+
+  defp join_field_path("", field), do: to_string(field)
+  defp join_field_path(path, field), do: "#{path}.#{field}"
 end

--- a/apps/trogon_ecto/lib/trogon/ecto/error_message.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/error_message.ex
@@ -6,6 +6,11 @@ defmodule Trogon.Ecto.ErrorMessage do
     Enum.reduce(opts, message, &replace_binding/2)
   end
 
+  @spec interpolates?(String.t(), atom()) :: boolean()
+  def interpolates?(message, key) do
+    String.contains?(message, placeholder(key))
+  end
+
   defp replace_binding({key, value}, message) do
     placeholder = placeholder(key)
 

--- a/apps/trogon_ecto/lib/trogon/ecto/field_violation.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/field_violation.ex
@@ -1,0 +1,72 @@
+defmodule Trogon.Ecto.FieldViolation do
+  @moduledoc """
+  A single changeset error, reduced to the field it is about, why it failed, and
+  what to tell the caller, both as a message and as the template and bindings it
+  was rendered from.
+
+  Built by `Trogon.Ecto.Changeset.field_violations/1`.
+  """
+
+  @enforce_keys [:field, :reason, :message, :template, :metadata]
+  defstruct [:field, :reason, :message, :template, :metadata]
+
+  @typedoc """
+  The path to the field that failed, with nested fields joined by `.` and
+  collection members indexed, such as `"items[0].sku"`.
+  """
+  @type field :: String.t()
+
+  @typedoc """
+  Why the field failed, as a stable atom derived from the error's metadata.
+
+  Validations report the `:validation` that failed, narrowed by its `:kind` where
+  Ecto provides one, so `validate_length/3` reports `:min_length` or `:max_length`
+  rather than `:length`. Constraints report a `_constraint` suffixed atom, keeping
+  `validate_exclusion/4` (`:exclusion`) distinct from `exclusion_constraint/3`
+  (`:exclusion_constraint`).
+
+  An error added with an atom `:code` in its metadata reports that instead, which
+  is the escape hatch for a reason that cannot be inferred. Anything left over is
+  `:unknown`.
+  """
+  @type reason :: atom()
+
+  @typedoc """
+  The message before interpolation, exactly as Ecto or a validation wrote it, with
+  its `%{...}` placeholders intact.
+
+  Together with `t:metadata/0` this is what a caller needs to render the message
+  itself, in its own language or its own wording, instead of taking ours:
+
+      Gettext.dgettext(MyApp.Gettext, "errors", violation.template, violation.metadata)
+
+  Interpolating the template with the metadata always reproduces `:message`.
+  """
+  @type template :: String.t()
+
+  @typedoc """
+  The bindings the template was rendered with, in the order Ecto put them there.
+
+  This is the bound a caller needs to render its own message, so a `:max_length`
+  violation carries `[count: 5]`, an `:inclusion` violation carries the `:enum` it
+  was checked against, and a `:greater_than` violation carries the `:number`.
+
+  A key that only repeats what `t:reason/0` already says is left out, namely
+  `:validation`, `:constraint`, `:kind`, and `:code`, as is Ecto's `:type`, which
+  it injects into every cast error and which describes the field rather than the
+  failure. A key is kept regardless if the template interpolates it, so the
+  template and the metadata are never out of step.
+
+  Everything else survives, including `:constraint_name`, which names a database
+  index. Decide whether that should reach the caller before passing this through.
+  """
+  @type metadata :: keyword()
+
+  @type t :: %__MODULE__{
+          field: field(),
+          reason: reason(),
+          message: String.t(),
+          template: template(),
+          metadata: metadata()
+        }
+end

--- a/apps/trogon_ecto/test/support/test_support.ex
+++ b/apps/trogon_ecto/test/support/test_support.ex
@@ -311,6 +311,30 @@ defmodule Trogon.Ecto.TestSupport do
     end
   end
 
+  defmodule Basket do
+    @moduledoc false
+    use Ecto.Schema
+
+    @primary_key false
+    embedded_schema do
+      embeds_many :items, Item, on_replace: :delete, primary_key: {:id, :string, []} do
+        field :sku, :string
+      end
+    end
+
+    def changeset(basket, attrs) do
+      basket
+      |> Ecto.Changeset.cast(attrs, [])
+      |> Ecto.Changeset.cast_embed(:items, with: &item_changeset/2)
+    end
+
+    defp item_changeset(item, attrs) do
+      item
+      |> Ecto.Changeset.cast(attrs, [:id, :sku])
+      |> Ecto.Changeset.validate_required([:sku])
+    end
+  end
+
   def errors_on(changeset) do
     PolymorphicEmbed.traverse_errors(changeset, fn {message, opts} ->
       Regex.replace(~r"%{(\w+)}", message, fn _, key ->

--- a/apps/trogon_ecto/test/trogon/ecto/changeset_test.exs
+++ b/apps/trogon_ecto/test/trogon/ecto/changeset_test.exs
@@ -99,4 +99,383 @@ defmodule Trogon.Ecto.ChangesetTest do
       end
     end
   end
+
+  describe "field_violations/1" do
+    test "is empty for a changeset with no errors" do
+      assert Trogon.Ecto.Changeset.field_violations(changeset(%{title: "hello"})) == []
+    end
+
+    test "reports the field, the reason, and the interpolated message" do
+      result =
+        %{title: "hello"}
+        |> changeset()
+        |> Ecto.Changeset.validate_length(:title, max: 3)
+        |> Trogon.Ecto.Changeset.field_violations()
+
+      assert result == [
+               %Trogon.Ecto.FieldViolation{
+                 field: "title",
+                 reason: :max_length,
+                 message: "should be at most 3 character(s)",
+                 template: "should be at most %{count} character(s)",
+                 metadata: [count: 3]
+               }
+             ]
+    end
+
+    test "reports one violation per error on the same field" do
+      result =
+        %{title: "hello"}
+        |> changeset()
+        |> Ecto.Changeset.validate_length(:title, max: 3)
+        |> Ecto.Changeset.validate_format(:title, ~r/^[0-9]+$/)
+        |> Trogon.Ecto.Changeset.field_violations()
+
+      assert Enum.map(result, & &1.reason) == [:format, :max_length]
+      assert Enum.map(result, & &1.field) == ["title", "title"]
+    end
+
+    test "sorts by field path" do
+      result =
+        %{title: "hello", views: "many"}
+        |> changeset()
+        |> Ecto.Changeset.validate_length(:title, max: 3)
+        |> Trogon.Ecto.Changeset.field_violations()
+
+      assert Enum.map(result, & &1.field) == ["title", "views"]
+    end
+
+    test "interpolates a message whose metadata cannot be a string" do
+      result =
+        %{}
+        |> changeset()
+        |> Ecto.Changeset.add_error(:tags, "got %{value}", value: {:a, :b})
+        |> Trogon.Ecto.Changeset.field_violations()
+
+      assert result == [
+               %Trogon.Ecto.FieldViolation{
+                 field: "tags",
+                 reason: :unknown,
+                 message: "got {:a, :b}",
+                 template: "got %{value}",
+                 metadata: [value: {:a, :b}]
+               }
+             ]
+    end
+
+    test "leaves a placeholder with no matching metadata alone" do
+      result =
+        %{}
+        |> changeset()
+        |> Ecto.Changeset.add_error(:tags, "got %{nothing}")
+        |> Trogon.Ecto.Changeset.field_violations()
+
+      assert [%Trogon.Ecto.FieldViolation{message: "got %{nothing}"}] = result
+    end
+
+    test "does not interpolate the :type Ecto injects into a cast error" do
+      result =
+        %{tags: "not a list"}
+        |> changeset()
+        |> Trogon.Ecto.Changeset.field_violations()
+
+      assert result == [
+               %Trogon.Ecto.FieldViolation{
+                 field: "tags",
+                 reason: :cast,
+                 message: "is invalid",
+                 template: "is invalid",
+                 metadata: []
+               }
+             ]
+    end
+  end
+
+  describe "field_violations/1 templates and metadata" do
+    test "carries the bindings the template was rendered with" do
+      result =
+        %{views: 2}
+        |> changeset()
+        |> Ecto.Changeset.validate_number(:views, greater_than: 5)
+        |> Trogon.Ecto.Changeset.field_violations()
+
+      assert [violation] = result
+      assert violation.message == "must be greater than 5"
+      assert violation.template == "must be greater than %{number}"
+      assert violation.metadata == [number: 5]
+    end
+
+    test "carries the set an inclusion was checked against" do
+      result =
+        %{title: "hello"}
+        |> changeset()
+        |> Ecto.Changeset.validate_inclusion(:title, ["a", "b"])
+        |> Trogon.Ecto.Changeset.field_violations()
+
+      assert [%{metadata: [enum: ["a", "b"]]}] = result
+    end
+
+    test "carries the name of the constraint that failed" do
+      result =
+        %{}
+        |> changeset()
+        |> Ecto.Changeset.add_error(:title, "has already been taken",
+          constraint: :unique,
+          constraint_name: "titles_pkey"
+        )
+        |> Trogon.Ecto.Changeset.field_violations()
+
+      assert [%{reason: :unique_constraint, metadata: [constraint_name: "titles_pkey"]}] = result
+    end
+
+    test "drops the keys the reason is derived from" do
+      result =
+        %{}
+        |> changeset()
+        |> Ecto.Changeset.add_error(:title, "nope",
+          validation: :length,
+          kind: :max,
+          code: :too_long,
+          count: 3
+        )
+        |> Trogon.Ecto.Changeset.field_violations()
+
+      assert [%{reason: :too_long, metadata: [count: 3]}] = result
+    end
+
+    test "drops the :type Ecto injects into a cast error" do
+      assert [%{metadata: []}] =
+               Trogon.Ecto.Changeset.field_violations(changeset(%{views: "many"}))
+    end
+
+    test "keeps a derived key the template interpolates" do
+      assert {:error, changeset} = TestSupport.MultiPlaceholderMessage.new(%{code: "x"})
+
+      assert [violation] = Trogon.Ecto.Changeset.field_violations(changeset)
+      assert violation.message == "2 of list"
+      assert violation.template == "%{count} of %{kind}"
+      assert violation.metadata == [count: 2, kind: :list]
+    end
+
+    test "interpolating the template with the metadata reproduces the message" do
+      changesets = [
+        changeset(%{views: "many"}),
+        Ecto.Changeset.validate_length(changeset(%{title: "hello"}), :title, max: 3),
+        Ecto.Changeset.validate_number(changeset(%{views: 2}), :views, greater_than: 5),
+        Ecto.Changeset.validate_required(changeset(%{}), [:title]),
+        elem(TestSupport.MultiPlaceholderMessage.new(%{code: "x"}), 1),
+        elem(TestSupport.InspectedMetadataMessage.new(%{code: "x"}), 1)
+      ]
+
+      for changeset <- changesets,
+          violation <- Trogon.Ecto.Changeset.field_violations(changeset) do
+        assert Trogon.Ecto.ErrorMessage.interpolate({violation.template, violation.metadata}) ==
+                 violation.message
+      end
+    end
+  end
+
+  describe "field_violations/1 reasons" do
+    test "narrows a length error by its kind" do
+      for {opts, reason} <- [{[min: 8], :min_length}, {[max: 3], :max_length}, {[is: 9], :length}] do
+        result =
+          %{title: "hello"}
+          |> changeset()
+          |> Ecto.Changeset.validate_length(:title, opts)
+          |> Trogon.Ecto.Changeset.field_violations()
+
+        assert [%Trogon.Ecto.FieldViolation{reason: ^reason}] = result
+      end
+    end
+
+    test "reports a number error by its kind rather than as :number" do
+      for {opts, reason} <- [
+            {[greater_than: 5], :greater_than},
+            {[less_than: 0], :less_than},
+            {[equal_to: 7], :equal_to},
+            {[not_equal_to: 1], :not_equal_to},
+            {[greater_than_or_equal_to: 5], :greater_than_or_equal_to},
+            {[less_than_or_equal_to: 0], :less_than_or_equal_to}
+          ] do
+        result =
+          %{views: 1}
+          |> changeset()
+          |> Ecto.Changeset.validate_number(:views, opts)
+          |> Trogon.Ecto.Changeset.field_violations()
+
+        assert [%Trogon.Ecto.FieldViolation{reason: ^reason}] = result
+      end
+    end
+
+    test "reports the validation for every other validation" do
+      cases = [
+        {%{}, &Ecto.Changeset.validate_required(&1, [:title]), :required},
+        {%{title: "hello"}, &Ecto.Changeset.validate_format(&1, :title, ~r/^[0-9]+$/), :format},
+        {%{title: "hello"}, &Ecto.Changeset.validate_inclusion(&1, :title, ["a"]), :inclusion},
+        {%{title: "hello"}, &Ecto.Changeset.validate_exclusion(&1, :title, ["hello"]), :exclusion},
+        {%{tags: ["b"]}, &Ecto.Changeset.validate_subset(&1, :tags, ["a"]), :subset},
+        {%{title: "hello"}, &Trogon.Ecto.Changeset.validate_unset(&1, :title), :unset}
+      ]
+
+      for {attrs, validation, reason} <- cases do
+        result =
+          attrs
+          |> changeset()
+          |> validation.()
+          |> Trogon.Ecto.Changeset.field_violations()
+
+        assert [%Trogon.Ecto.FieldViolation{reason: ^reason}] = result
+      end
+    end
+
+    test "suffixes a constraint so it cannot be mistaken for a validation" do
+      for {constraint, reason} <- [
+            {:unique, :unique_constraint},
+            {:foreign, :foreign_constraint},
+            {:assoc, :assoc_constraint},
+            {:no_assoc, :no_assoc_constraint},
+            {:check, :check_constraint},
+            {:exclusion, :exclusion_constraint}
+          ] do
+        result =
+          %{}
+          |> changeset()
+          |> Ecto.Changeset.add_error(:title, "is invalid",
+            constraint: constraint,
+            constraint_name: "some_index"
+          )
+          |> Trogon.Ecto.Changeset.field_violations()
+
+        assert [%Trogon.Ecto.FieldViolation{reason: ^reason}] = result
+      end
+    end
+
+    test "keeps validate_exclusion distinct from exclusion_constraint" do
+      validation =
+        %{title: "hello"}
+        |> changeset()
+        |> Ecto.Changeset.validate_exclusion(:title, ["hello"])
+        |> Trogon.Ecto.Changeset.field_violations()
+
+      constraint =
+        %{}
+        |> changeset()
+        |> Ecto.Changeset.add_error(:title, "is invalid", constraint: :exclusion, constraint_name: "x")
+        |> Trogon.Ecto.Changeset.field_violations()
+
+      assert [%{reason: :exclusion}] = validation
+      assert [%{reason: :exclusion_constraint}] = constraint
+    end
+
+    test "honors an atom :code over anything inferred" do
+      result =
+        %{}
+        |> changeset()
+        |> Ecto.Changeset.add_error(:title, "nope", code: :not_allowed, validation: :required)
+        |> Trogon.Ecto.Changeset.field_violations()
+
+      assert [%Trogon.Ecto.FieldViolation{reason: :not_allowed}] = result
+    end
+
+    test "ignores a :code that is not an atom" do
+      result =
+        %{}
+        |> changeset()
+        |> Ecto.Changeset.add_error(:title, "nope", code: "not_allowed", validation: :required)
+        |> Trogon.Ecto.Changeset.field_violations()
+
+      assert [%Trogon.Ecto.FieldViolation{reason: :required}] = result
+    end
+
+    test "is :unknown for an error with no metadata to go on" do
+      result =
+        %{}
+        |> changeset()
+        |> Ecto.Changeset.add_error(:title, "nope")
+        |> Trogon.Ecto.Changeset.field_violations()
+
+      assert [%Trogon.Ecto.FieldViolation{reason: :unknown}] = result
+    end
+  end
+
+  describe "field_violations/1 with nested changesets" do
+    test "reports an embed given the wrong shape on the parent field" do
+      assert {:error, changeset} = TestSupport.MessageThree.new(%{target: "not a map"})
+
+      assert Trogon.Ecto.Changeset.field_violations(changeset) == [
+               %Trogon.Ecto.FieldViolation{
+                 field: "target",
+                 reason: :embed,
+                 message: "is invalid",
+                 template: "is invalid",
+                 metadata: []
+               }
+             ]
+    end
+
+    test "indexes a member of a collection" do
+      assert {:error, changeset} =
+               TestSupport.MessageFour.new(%{targets: [%{}, %{target: %{}}]})
+
+      assert Trogon.Ecto.Changeset.field_violations(changeset) == [
+               %Trogon.Ecto.FieldViolation{
+                 field: "targets[0].target",
+                 reason: :required,
+                 message: "can't be blank",
+                 template: "can't be blank",
+                 metadata: []
+               }
+             ]
+    end
+
+    test "traverses a polymorphic embed" do
+      assert {:error, changeset} =
+               TestSupport.NotificationWithPolymorphicEmbed.new(%{
+                 title: "hello",
+                 content: %{__type__: "email"}
+               })
+
+      assert Trogon.Ecto.Changeset.field_violations(changeset) == [
+               %Trogon.Ecto.FieldViolation{
+                 field: "content.body",
+                 reason: :required,
+                 message: "can't be blank",
+                 template: "can't be blank",
+                 metadata: []
+               },
+               %Trogon.Ecto.FieldViolation{
+                 field: "content.subject",
+                 reason: :required,
+                 message: "can't be blank",
+                 template: "can't be blank",
+                 metadata: []
+               }
+             ]
+    end
+
+    test "indexes against the collection the caller sent, not the one Ecto traverses" do
+      data = %TestSupport.Basket{
+        items: [
+          %TestSupport.Basket.Item{id: "a", sku: "dropped"},
+          %TestSupport.Basket.Item{id: "b", sku: "kept"}
+        ]
+      }
+
+      changeset = TestSupport.Basket.changeset(data, %{items: [%{id: "b", sku: nil}]})
+
+      assert Ecto.Changeset.traverse_errors(changeset, & &1) == %{
+               items: [%{}, %{sku: [{"can't be blank", [validation: :required]}]}]
+             }
+
+      assert Trogon.Ecto.Changeset.field_violations(changeset) == [
+               %Trogon.Ecto.FieldViolation{
+                 field: "items[0].sku",
+                 reason: :required,
+                 message: "can't be blank",
+                 template: "can't be blank",
+                 metadata: []
+               }
+             ]
+    end
+  end
 end

--- a/apps/trogon_ecto/test/trogon/ecto/error_message_test.exs
+++ b/apps/trogon_ecto/test/trogon/ecto/error_message_test.exs
@@ -68,4 +68,27 @@ defmodule Trogon.Ecto.ErrorMessageTest do
                "is invalid"
     end
   end
+
+  describe "interpolates?/2" do
+    test "is true when the message holds the placeholder for the key" do
+      assert ErrorMessage.interpolates?("should be at most %{count} character(s)", :count)
+    end
+
+    test "is false when the message does not hold the placeholder" do
+      refute ErrorMessage.interpolates?("should be at most %{count} character(s)", :kind)
+    end
+
+    test "is false when the key is named in the message but not as a placeholder" do
+      refute ErrorMessage.interpolates?("count is wrong", :count)
+    end
+
+    test "is true for any one of several placeholders" do
+      assert ErrorMessage.interpolates?("%{count} of %{kind}", :count)
+      assert ErrorMessage.interpolates?("%{count} of %{kind}", :kind)
+    end
+
+    test "does not match a key that is only the prefix of a placeholder" do
+      refute ErrorMessage.interpolates?("got %{count_total}", :count)
+    end
+  end
 end


### PR DESCRIPTION
- An API layer has to answer "which field, and why" for every error, and a changeset does not give that: errors arrive nested, keyed by atom, with the message still holding its placeholders.
- The index a changeset reports counts members that are on their way out, so a caller following it lands on the wrong element of the collection they sent. That is a correctness problem, not a cosmetic one, and it belongs in one place instead of in every consumer.
- Callers that own their own wording, or that translate, need the message before interpolation together with its bindings. Handing them only the rendered string forces them to parse it back apart.
- Branching on a reason should not mean matching on English prose.
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
