### PR TITLE
feat(trogon_ecto): add string map, label map, and annotation map types

### DIFF
--- a/apps/trogon_ecto/lib/trogon/ecto/annotation_map.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/annotation_map.ex
@@ -1,0 +1,92 @@
+defmodule Trogon.Ecto.AnnotationMap do
+  alias Trogon.Ecto.FieldOptions
+  alias Trogon.Ecto.StringMap
+
+  @forced [key_format: :qualified_name_ignoring_case, value_format: :any]
+
+  @opts_schema NimbleOptions.new!(
+                 [
+                   max_key_length: [
+                     type: {:or, [:pos_integer, {:in, [:infinity]}]},
+                     default: :infinity,
+                     doc: "Maximum key length in bytes, whole key included."
+                   ],
+                   max_value_length: [
+                     type: {:or, [:pos_integer, {:in, [:infinity]}]},
+                     default: :infinity,
+                     doc: "Maximum value length in bytes."
+                   ]
+                 ] ++ FieldOptions.nimble_schema()
+               )
+
+  @moduledoc """
+  Non-identifying metadata, the Kubernetes `metadata.annotations` rules under a name.
+
+      defmodule Deployment do
+        use Ecto.Schema
+
+        schema "deployments" do
+          field :annotations, Trogon.Ecto.AnnotationMap, max_value_length: 4_096
+        end
+      end
+
+  Nothing selects on an annotation, so only the key is constrained:
+
+  - a key is a qualified name, `name` or `prefix/name`, matched against its
+    lowercased form, which is what `ValidateAnnotations` does. `Example.com/tier`
+    is a valid annotation key and an invalid label key.
+  - a value is any string, a sentence or a JSON document alike
+
+  See `Trogon.Ecto.StringMap` for the key rule and for the shape every entry shares
+  with a label.
+
+  Kubernetes also caps a whole annotations map at 256 KiB, which is a limit on what
+  its own storage will take rather than a property of the shape, so it is left to
+  you. `max_value_length` is the bound to reach for, since an unconstrained value
+  is otherwise as large as the column will hold.
+
+  The rules are the type, so `key_format` and `value_format` cannot be passed here.
+  Use `Trogon.Ecto.StringMap` for a map whose rules you choose.
+
+  ## Options
+
+  #{NimbleOptions.docs(@opts_schema)}
+
+  A rejected value fails the changeset with `validation: :annotation_map`, and
+  otherwise reports exactly as `Trogon.Ecto.StringMap` does.
+  """
+
+  use Ecto.ParameterizedType
+
+  @typedoc "A map of strings to strings."
+  @type t :: StringMap.t()
+
+  @typedoc "An annotation map's rules, built by Ecto from `field/3`."
+  @type params :: StringMap.params()
+
+  @impl Ecto.ParameterizedType
+  @spec init(keyword()) :: params()
+  def init(opts), do: StringMap.init_preset(opts, @forced, :annotation_map)
+
+  @impl Ecto.ParameterizedType
+  @spec type(params()) :: :map
+  def type(params), do: StringMap.type(params)
+
+  @impl Ecto.ParameterizedType
+  @spec cast(term(), params()) :: {:ok, t() | nil} | {:error, keyword()} | :error
+  def cast(value, params), do: StringMap.cast(value, params)
+
+  @impl Ecto.ParameterizedType
+  @spec load(term(), (Ecto.Type.t(), term() -> {:ok, term()} | :error), params()) ::
+          {:ok, map() | nil} | :error
+  def load(value, loader, params), do: StringMap.load(value, loader, params)
+
+  @impl Ecto.ParameterizedType
+  @spec dump(term(), (Ecto.Type.t(), term() -> {:ok, term()} | :error), params()) ::
+          {:ok, t() | nil} | :error
+  def dump(value, dumper, params), do: StringMap.dump(value, dumper, params)
+
+  @impl Ecto.ParameterizedType
+  @spec embed_as(atom(), params()) :: :dump
+  def embed_as(format, params), do: StringMap.embed_as(format, params)
+end

--- a/apps/trogon_ecto/lib/trogon/ecto/label_map.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/label_map.ex
@@ -1,0 +1,86 @@
+defmodule Trogon.Ecto.LabelMap do
+  alias Trogon.Ecto.FieldOptions
+  alias Trogon.Ecto.StringMap
+
+  @forced [key_format: :qualified_name, value_format: :label_value]
+
+  @opts_schema NimbleOptions.new!(
+                 [
+                   max_key_length: [
+                     type: {:or, [:pos_integer, {:in, [:infinity]}]},
+                     default: :infinity,
+                     doc: "Maximum key length in bytes, whole key included."
+                   ],
+                   max_value_length: [
+                     type: {:or, [:pos_integer, {:in, [:infinity]}]},
+                     default: :infinity,
+                     doc: "Maximum value length in bytes."
+                   ]
+                 ] ++ FieldOptions.nimble_schema()
+               )
+
+  @moduledoc """
+  Identifying metadata, the Kubernetes `metadata.labels` rules under a name.
+
+      defmodule Deployment do
+        use Ecto.Schema
+
+        schema "deployments" do
+          field :labels, Trogon.Ecto.LabelMap
+        end
+      end
+
+  A label is meant to be selected on, so both halves of an entry are constrained:
+
+  - a key is a qualified name, `name` or `prefix/name`
+  - a value is an empty string, or a name
+
+  See `Trogon.Ecto.StringMap` for what those two rules are, and for the shape every
+  entry shares with an annotation. Unlike an annotation key, a label key is
+  case sensitive, matching `ValidateLabels` rather than `ValidateAnnotations`.
+
+  The rules are the type, so `key_format` and `value_format` cannot be passed here.
+  Use `Trogon.Ecto.StringMap` for a map whose rules you choose.
+
+  ## Options
+
+  #{NimbleOptions.docs(@opts_schema)}
+
+  A rejected value fails the changeset with `validation: :label_map`, and otherwise
+  reports exactly as `Trogon.Ecto.StringMap` does.
+  """
+
+  use Ecto.ParameterizedType
+
+  @typedoc "A map of strings to strings."
+  @type t :: StringMap.t()
+
+  @typedoc "A label map's rules, built by Ecto from `field/3`."
+  @type params :: StringMap.params()
+
+  @impl Ecto.ParameterizedType
+  @spec init(keyword()) :: params()
+  def init(opts), do: StringMap.init_preset(opts, @forced, :label_map)
+
+  @impl Ecto.ParameterizedType
+  @spec type(params()) :: :map
+  def type(params), do: StringMap.type(params)
+
+  @impl Ecto.ParameterizedType
+  @spec cast(term(), params()) :: {:ok, t() | nil} | {:error, keyword()} | :error
+  def cast(value, params), do: StringMap.cast(value, params)
+
+  @impl Ecto.ParameterizedType
+  @spec load(term(), (Ecto.Type.t(), term() -> {:ok, term()} | :error), params()) ::
+          {:ok, map() | nil} | :error
+  def load(value, loader, params), do: StringMap.load(value, loader, params)
+
+  @impl Ecto.ParameterizedType
+  @spec dump(term(), (Ecto.Type.t(), term() -> {:ok, term()} | :error), params()) ::
+          {:ok, t() | nil} | :error
+  def dump(value, dumper, params), do: StringMap.dump(value, dumper, params)
+
+  @impl Ecto.ParameterizedType
+  @spec embed_as(atom(), params()) :: :dump
+  def embed_as(format, params), do: StringMap.embed_as(format, params)
+end

--- a/apps/trogon_ecto/lib/trogon/ecto/migration.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/migration.ex
@@ -13,7 +13,8 @@ defmodule Trogon.Ecto.Migration do
         add_object_id_column(:owner_id, null: false)
         add_currency_code_column()
         add_money_amount_column(:balance)
-        add_annotations_column()
+        add_string_map_column(:labels, null: false)
+        add_string_map_column(:annotations)
         add_timestamps()
       end
     end
@@ -135,13 +136,36 @@ defmodule Trogon.Ecto.Migration do
   end
 
   @doc """
-  Adds an `:annotations` column, typed as `:map`, for free-form metadata.
+  Adds a `:jsonb` column for a `Trogon.Ecto.StringMap`, `Trogon.Ecto.LabelMap`, or
+  `Trogon.Ecto.AnnotationMap` field.
+
+  Defaults to `default: "{}"`; caller opts win. An empty map rather than `NULL`
+  keeps a read from having to tell an absent map from one with no entries.
+
+  `:jsonb` rather than Ecto's `:map`, which PostgreSQL renders as whatever
+  `config :ecto_sql, :postgres_map_type` says, `"jsonb"` unless an application
+  sets it to `"json"`. A map that lands in a `json` column keeps duplicate keys
+  and insertion order verbatim, so two writes of the same map are two different
+  stored values, and it cannot take the GIN index a lookup by label needs.
+
+  ## Examples
+
+      add_string_map_column(:labels, null: false)
+  """
+  @spec add_string_map_column(name :: atom(), opts :: Keyword.t()) :: term()
+  def add_string_map_column(name, opts \\ []) when is_atom(name) do
+    Ecto.Migration.add(name, :jsonb, Keyword.merge([default: "{}"], opts))
+  end
+
+  @doc """
+  Adds an `:annotations` column, typed as `:jsonb`, for free-form metadata.
 
   Defaults to `default: "{}"`; caller opts win.
   """
+  @deprecated "Use add_string_map_column/2 instead"
   @spec add_annotations_column(opts :: Keyword.t()) :: term()
   def add_annotations_column(opts \\ []) do
-    Ecto.Migration.add(:annotations, :map, Keyword.merge([default: "{}"], opts))
+    add_string_map_column(:annotations, opts)
   end
 
   @doc """

--- a/apps/trogon_ecto/lib/trogon/ecto/string_map.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/string_map.ex
@@ -1,0 +1,328 @@
+defmodule Trogon.Ecto.StringMap do
+  alias Trogon.Ecto.FieldOptions
+
+  @own_keys [:key_format, :value_format, :max_key_length, :max_value_length]
+
+  @name_max_length 63
+  @prefix_max_length 253
+  @value_max_length 63
+
+  @name_regex ~r/\A[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?\z/
+  @prefix_regex ~r/\A[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\z/
+
+  @opts_schema NimbleOptions.new!(
+                 [
+                   key_format: [
+                     type: {:in, [:any, :qualified_name, :qualified_name_ignoring_case]},
+                     default: :any,
+                     doc: """
+                     Syntax every key must follow. `:any` accepts any string.
+                     `:qualified_name` is `name` or `prefix/name`.
+                     `:qualified_name_ignoring_case` is the same rule applied to
+                     the lowercased key.
+                     """
+                   ],
+                   value_format: [
+                     type: {:in, [:any, :label_value]},
+                     default: :any,
+                     doc: """
+                     Syntax every value must follow. `:any` accepts any string.
+                     `:label_value` is empty, or a name.
+                     """
+                   ],
+                   max_key_length: [
+                     type: {:or, [:pos_integer, {:in, [:infinity]}]},
+                     default: :infinity,
+                     doc: "Maximum key length in bytes, whole key included."
+                   ],
+                   max_value_length: [
+                     type: {:or, [:pos_integer, {:in, [:infinity]}]},
+                     default: :infinity,
+                     doc: "Maximum value length in bytes."
+                   ]
+                 ] ++ FieldOptions.nimble_schema()
+               )
+
+  @moduledoc """
+  A map of strings to strings, with the rules a key and a value must follow left
+  to the field.
+
+  It is modelled on Kubernetes, which holds `metadata.labels` and
+  `metadata.annotations` as `map[string]string` and validates each of them
+  differently. `Trogon.Ecto.LabelMap` and `Trogon.Ecto.AnnotationMap` are those
+  two rule sets under their own names; reach for this type when neither fits.
+
+      defmodule Deployment do
+        use Ecto.Schema
+
+        schema "deployments" do
+          field :tags, Trogon.Ecto.StringMap
+
+          field :selector, Trogon.Ecto.StringMap,
+            key_format: :qualified_name,
+            value_format: :label_value,
+            max_value_length: 32
+        end
+      end
+
+  ## Options
+
+  #{NimbleOptions.docs(@opts_schema)}
+
+  Every option is unset by default, so a bare `field :tags, Trogon.Ecto.StringMap`
+  constrains the shape and nothing else.
+
+  ## What a field accepts
+
+  Every key and every value must already be a string. Nothing is converted, for the
+  same reason Kubernetes rejects `replicas: 3` in a labels block rather than reading
+  it as `"3"`: a map that takes both `3` and `"3"` has two spellings for one entry,
+  and only one of them survives a round trip.
+
+  `nil` is never made into a string. A `nil` value is rejected rather than stored as
+  `""`, which would turn an absent value into a present empty one. A `nil` field
+  stays `nil`, an absent map rather than an empty one.
+
+  An empty string value is allowed, as `app.kubernetes.io/part-of: ""` is in
+  Kubernetes.
+
+  ## Formats
+
+  A qualified name is `name` or `prefix/name`, and nothing with a second `/`.
+
+  - `name` is 1 to #{@name_max_length} characters, begins and ends with an
+    alphanumeric, and may hold `-`, `_`, and `.` in between.
+  - `prefix` is a DNS subdomain of at most #{@prefix_max_length} characters: dot
+    separated labels of lowercase alphanumerics and `-`, each beginning and ending
+    with an alphanumeric.
+
+  A label value is an empty string, or 1 to #{@value_max_length} characters under
+  the same rule as `name`.
+
+  Lengths are counted in bytes, which both rules make equivalent to characters by
+  admitting only ASCII.
+
+  ## Length bounds
+
+  `max_key_length` and `max_value_length` bound the whole key and the whole value,
+  and apply whatever the formats are. They are the only bound a field has under
+  `:any`, where a value is otherwise as large as the column will hold.
+
+  Under a format they narrow it: the key bound covers `prefix/name` together rather
+  than either part, so the shorter of the two rules is what a key has to satisfy.
+
+  ## Reads are lenient, writes are not
+
+  `load/3` accepts any map, so rows written before this type was in place still
+  load, as do rows written before a rule was tightened. Writing one of those rows
+  back is what fails, since `dump/3` holds a value to the same rules as `cast/2`.
+
+  That holds for a field nested in an embed too, which is why the type is embedded
+  as its dumped form rather than as itself.
+
+  A row the rules reject is only a problem on the way back out, and `c:Ecto.Repo.update/2`
+  dumps the fields in the changeset, so one of those rows survives an update that
+  leaves the map alone. For the write that does have to touch it, either declare the
+  field as this type with the rules the stored data already meets, or reach past the
+  type with `c:Ecto.Repo.update_all/3`, which is also how a backfill is best written.
+
+  ## Errors
+
+  A rejected value fails the changeset with `validation: :string_map` and one of:
+
+  - `"has a key that is not a string"`
+  - `"has a value that is not a string"`
+  - `"has a key longer than %{max_length} bytes"`
+  - `"has a value longer than %{max_length} bytes for key: %{key}"`
+  - `"has an invalid key: %{key}"`
+  - `"has an invalid value for key: %{key}"`
+
+  The offending key is metadata on every one of those that has a key to name,
+  interpolated into the message or not. `Trogon.Ecto.LabelMap` and
+  `Trogon.Ecto.AnnotationMap` report their own name as the validation instead.
+  """
+
+  use Ecto.ParameterizedType
+
+  @typedoc "A map of strings to strings."
+  @type t :: %{optional(String.t()) => String.t()}
+
+  @typedoc "A field's key and value rules, built by Ecto from `field/3`."
+  @type params :: %{
+          key_format: :any | :qualified_name | :qualified_name_ignoring_case,
+          value_format: :any | :label_value,
+          max_key_length: pos_integer() | :infinity,
+          max_value_length: pos_integer() | :infinity,
+          validation: atom()
+        }
+
+  @impl Ecto.ParameterizedType
+  @spec init(keyword()) :: params()
+  def init(opts) do
+    opts
+    |> NimbleOptions.validate!(@opts_schema)
+    |> Keyword.take(@own_keys)
+    |> Map.new()
+    |> Map.put(:validation, :string_map)
+  end
+
+  @doc false
+  @spec init_preset(keyword(), keyword(), atom()) :: params()
+  def init_preset(opts, forced, validation) do
+    Enum.each(forced, fn {key, _value} ->
+      if Keyword.has_key?(opts, key) do
+        raise ArgumentError,
+              "cannot set #{inspect(key)} on this type, its rules are fixed, " <>
+                "use Trogon.Ecto.StringMap for a map whose rules you choose"
+      end
+    end)
+
+    opts
+    |> Keyword.merge(forced)
+    |> init()
+    |> Map.put(:validation, validation)
+  end
+
+  @impl Ecto.ParameterizedType
+  @spec type(params()) :: :map
+  def type(_params), do: :map
+
+  @impl Ecto.ParameterizedType
+  @spec cast(term(), params()) :: {:ok, t() | nil} | {:error, keyword()} | :error
+  def cast(nil, _params), do: {:ok, nil}
+
+  def cast(value, params) when is_map(value) and not is_struct(value) do
+    Enum.reduce_while(value, {:ok, value}, fn pair, acc ->
+      case validate_pair(pair, params) do
+        :ok -> {:cont, acc}
+        {:error, error} -> {:halt, {:error, error}}
+      end
+    end)
+  end
+
+  def cast(_value, _params), do: :error
+
+  defp validate_pair({key, value}, params) do
+    with :ok <- validate_key(key, params) do
+      validate_value(key, value, params)
+    end
+  end
+
+  defp validate_key(key, params) when not is_binary(key) do
+    {:error, error(params, "has a key that is not a string")}
+  end
+
+  defp validate_key(key, params) do
+    with :ok <- validate_key_length(key, params) do
+      validate_key_format(key, params)
+    end
+  end
+
+  defp validate_key_length(key, params) do
+    if within_length?(key, params.max_key_length) do
+      :ok
+    else
+      {:error,
+       error(params, "has a key longer than %{max_length} bytes",
+         max_length: params.max_key_length,
+         key: key
+       )}
+    end
+  end
+
+  defp validate_key_format(key, %{key_format: :qualified_name} = params) do
+    if qualified_name?(key), do: :ok, else: {:error, invalid_key(params, key)}
+  end
+
+  defp validate_key_format(key, %{key_format: :qualified_name_ignoring_case} = params) do
+    if qualified_name?(String.downcase(key)), do: :ok, else: {:error, invalid_key(params, key)}
+  end
+
+  defp validate_key_format(_key, %{key_format: :any}), do: :ok
+
+  defp invalid_key(params, key), do: error(params, "has an invalid key: %{key}", key: key)
+
+  defp validate_value(key, value, params) when not is_binary(value) do
+    {:error, error(params, "has a value that is not a string", key: key)}
+  end
+
+  defp validate_value(key, value, params) do
+    with :ok <- validate_value_length(key, value, params) do
+      validate_value_format(key, value, params)
+    end
+  end
+
+  defp validate_value_length(key, value, params) do
+    if within_length?(value, params.max_value_length) do
+      :ok
+    else
+      {:error,
+       error(params, "has a value longer than %{max_length} bytes for key: %{key}",
+         max_length: params.max_value_length,
+         key: key
+       )}
+    end
+  end
+
+  defp validate_value_format(key, value, %{value_format: :label_value} = params) do
+    if label_value?(value),
+      do: :ok,
+      else: {:error, error(params, "has an invalid value for key: %{key}", key: key)}
+  end
+
+  defp validate_value_format(_key, _value, %{value_format: :any}), do: :ok
+
+  defp within_length?(_value, :infinity), do: true
+  defp within_length?(value, max_length), do: byte_size(value) <= max_length
+
+  defp qualified_name?(key) do
+    case String.split(key, "/") do
+      [name] -> name?(name)
+      [prefix, name] -> prefix?(prefix) and name?(name)
+      _parts -> false
+    end
+  end
+
+  defp name?(name) do
+    byte_size(name) in 1..@name_max_length and Regex.match?(@name_regex, name)
+  end
+
+  defp prefix?(prefix) do
+    byte_size(prefix) in 1..@prefix_max_length and Regex.match?(@prefix_regex, prefix)
+  end
+
+  defp label_value?(""), do: true
+
+  defp label_value?(value) do
+    byte_size(value) in 1..@value_max_length and Regex.match?(@name_regex, value)
+  end
+
+  defp error(params, message, metadata \\ []) do
+    [message: message] ++ metadata ++ [validation: params.validation]
+  end
+
+  @impl Ecto.ParameterizedType
+  @spec load(term(), (Ecto.Type.t(), term() -> {:ok, term()} | :error), params()) ::
+          {:ok, map() | nil} | :error
+  def load(nil, _loader, _params), do: {:ok, nil}
+  def load(value, _loader, _params) when is_map(value) and not is_struct(value), do: {:ok, value}
+  def load(_value, _loader, _params), do: :error
+
+  @impl Ecto.ParameterizedType
+  @spec dump(term(), (Ecto.Type.t(), term() -> {:ok, term()} | :error), params()) ::
+          {:ok, t() | nil} | :error
+  def dump(nil, _dumper, _params), do: {:ok, nil}
+
+  def dump(value, _dumper, params) when is_map(value) and not is_struct(value) do
+    case cast(value, params) do
+      {:ok, value} -> {:ok, value}
+      _error -> :error
+    end
+  end
+
+  def dump(_value, _dumper, _params), do: :error
+
+  @impl Ecto.ParameterizedType
+  @spec embed_as(atom(), params()) :: :dump
+  def embed_as(_format, _params), do: :dump
+end

--- a/apps/trogon_ecto/test/support/test_support.ex
+++ b/apps/trogon_ecto/test/support/test_support.ex
@@ -311,6 +311,40 @@ defmodule Trogon.Ecto.TestSupport do
     end
   end
 
+  defmodule WithStringMap do
+    @moduledoc false
+    use Trogon.Ecto.ValueObject
+
+    embedded_schema do
+      field :labels, Trogon.Ecto.StringMap
+    end
+  end
+
+  defmodule WithConfiguredStringMap do
+    @moduledoc false
+    use Trogon.Ecto.ValueObject
+
+    embedded_schema do
+      field :labels, Trogon.Ecto.StringMap,
+        key_format: :qualified_name,
+        value_format: :label_value
+
+      field :annotations, Trogon.Ecto.StringMap,
+        key_format: :qualified_name,
+        max_value_length: 64
+    end
+  end
+
+  defmodule WithKubernetesMetadata do
+    @moduledoc false
+    use Trogon.Ecto.ValueObject
+
+    embedded_schema do
+      field :labels, Trogon.Ecto.LabelMap
+      field :annotations, Trogon.Ecto.AnnotationMap, max_value_length: 64
+    end
+  end
+
   defmodule Basket do
     @moduledoc false
     use Ecto.Schema

--- a/apps/trogon_ecto/test/trogon/ecto/annotation_map_test.exs
+++ b/apps/trogon_ecto/test/trogon/ecto/annotation_map_test.exs
@@ -1,0 +1,143 @@
+defmodule Trogon.Ecto.AnnotationMapTest do
+  use ExUnit.Case, async: true
+
+  alias Trogon.Ecto.AnnotationMap
+  alias Trogon.Ecto.TestSupport.WithKubernetesMetadata
+
+  doctest AnnotationMap
+
+  @params AnnotationMap.init([])
+
+  describe "init/1" do
+    test "fixes the key rule and leaves values free" do
+      assert @params == %{
+               key_format: :qualified_name_ignoring_case,
+               value_format: :any,
+               max_key_length: :infinity,
+               max_value_length: :infinity,
+               validation: :annotation_map
+             }
+    end
+
+    test "keeps the given bounds" do
+      assert AnnotationMap.init(max_value_length: 4_096).max_value_length == 4_096
+    end
+
+    test "refuses to have its rules overridden" do
+      for opts <- [[key_format: :any], [value_format: :label_value]] do
+        assert_raise ArgumentError, ~r/its rules are fixed/, fn -> AnnotationMap.init(opts) end
+      end
+    end
+
+    test "rejects an unknown option" do
+      assert_raise NimbleOptions.ValidationError, ~r/unknown options \[:max_length\]/, fn ->
+        AnnotationMap.init(max_length: 8)
+      end
+    end
+  end
+
+  describe "type/1" do
+    test "is :map" do
+      assert AnnotationMap.type(@params) == :map
+    end
+  end
+
+  describe "cast/2" do
+    test "takes any value, which is the point of an annotation" do
+      value = %{
+        "example.com/note" => "a longer sentence, with punctuation.",
+        "example.com/config" => ~s({"replicas":3}),
+        "example.com/empty" => ""
+      }
+
+      assert AnnotationMap.cast(value, @params) == {:ok, value}
+    end
+
+    test "matches the key against its lowercased form, as Kubernetes does" do
+      for key <- ["Example.com/tier", "EXAMPLE.COM/Tier"] do
+        assert AnnotationMap.cast(%{key => "gold"}, @params) == {:ok, %{key => "gold"}}
+      end
+    end
+
+    test "still rejects a key that is no qualified name" do
+      for key <- ["-tier", "example.com/a/b", "tier gold", ""] do
+        assert {:error, [{:message, "has an invalid key: %{key}"} | _rest]} =
+                 AnnotationMap.cast(%{key => "gold"}, @params)
+      end
+    end
+
+    test "rejects a value that is not a string" do
+      assert AnnotationMap.cast(%{"example.com/tier" => nil}, @params) ==
+               {:error,
+                [
+                  message: "has a value that is not a string",
+                  key: "example.com/tier",
+                  validation: :annotation_map
+                ]}
+    end
+
+    test "passes nil through" do
+      assert AnnotationMap.cast(nil, @params) == {:ok, nil}
+    end
+
+    test "bounds a key when asked to" do
+      params = AnnotationMap.init(max_key_length: 8)
+
+      assert {:error, [{:message, "has a key longer than %{max_length} bytes"} | _rest]} =
+               AnnotationMap.cast(%{"example.com/note" => "a"}, params)
+    end
+
+    test "bounds a value when asked to" do
+      params = AnnotationMap.init(max_value_length: 8)
+
+      assert {:error, [{:message, "has a value longer than %{max_length} bytes for key: %{key}"} | _rest]} =
+               AnnotationMap.cast(%{"example.com/note" => "a longer sentence"}, params)
+    end
+  end
+
+  describe "load/3" do
+    test "is lenient, so a row written before this type still reads" do
+      assert AnnotationMap.load(%{"tier gold" => "gold"}, nil, @params) == {:ok, %{"tier gold" => "gold"}}
+    end
+  end
+
+  describe "dump/3" do
+    test "holds a value to the same rules as cast/2" do
+      assert AnnotationMap.dump(%{"tier" => "anything at all"}, nil, @params) ==
+               {:ok, %{"tier" => "anything at all"}}
+
+      assert AnnotationMap.dump(%{"-tier" => "gold"}, nil, @params) == :error
+    end
+  end
+
+  describe "embed_as/2" do
+    test "is :dump, so a nested field is validated on write" do
+      assert AnnotationMap.embed_as(:json, @params) == :dump
+    end
+  end
+
+  describe "schema field declarations" do
+    test "a field takes an annotation a label would reject" do
+      attrs = %{annotations: %{"example.com/note" => "a longer sentence, with punctuation."}}
+
+      assert {:ok, %WithKubernetesMetadata{}} = WithKubernetesMetadata.new(attrs)
+    end
+
+    test "a violation names the annotation map as its reason" do
+      value = String.duplicate("a", 65)
+
+      assert {:error, changeset} =
+               WithKubernetesMetadata.new(%{annotations: %{"example.com/note" => value}})
+
+      assert Trogon.Ecto.Changeset.field_violations(changeset) == [
+               %Trogon.Ecto.FieldViolation{
+                 field: "annotations",
+                 reason: :annotation_map,
+                 message: "has a value longer than 64 bytes for key: example.com/note",
+                 template: "has a value longer than %{max_length} bytes for key: %{key}",
+                 metadata: [max_length: 64, key: "example.com/note"]
+               }
+             ]
+    end
+  end
+end

--- a/apps/trogon_ecto/test/trogon/ecto/label_map_test.exs
+++ b/apps/trogon_ecto/test/trogon/ecto/label_map_test.exs
@@ -1,0 +1,135 @@
+defmodule Trogon.Ecto.LabelMapTest do
+  use ExUnit.Case, async: true
+
+  alias Trogon.Ecto.LabelMap
+  alias Trogon.Ecto.TestSupport.WithKubernetesMetadata
+
+  doctest LabelMap
+
+  @params LabelMap.init([])
+
+  describe "init/1" do
+    test "fixes both rules to the Kubernetes label rules" do
+      assert @params == %{
+               key_format: :qualified_name,
+               value_format: :label_value,
+               max_key_length: :infinity,
+               max_value_length: :infinity,
+               validation: :label_map
+             }
+    end
+
+    test "keeps the given bounds" do
+      assert LabelMap.init(max_key_length: 32, max_value_length: 8).max_value_length == 8
+    end
+
+    test "refuses to have its rules overridden" do
+      for opts <- [[key_format: :any], [value_format: :any], [key_format: :qualified_name]] do
+        assert_raise ArgumentError, ~r/its rules are fixed/, fn -> LabelMap.init(opts) end
+      end
+    end
+
+    test "rejects an unknown option" do
+      assert_raise NimbleOptions.ValidationError, ~r/unknown options \[:max_length\]/, fn ->
+        LabelMap.init(max_length: 8)
+      end
+    end
+  end
+
+  describe "type/1" do
+    test "is :map" do
+      assert LabelMap.type(@params) == :map
+    end
+  end
+
+  describe "cast/2" do
+    test "accepts a selectable entry" do
+      value = %{"tier" => "gold", "app.kubernetes.io/name" => "redis", "region" => ""}
+
+      assert LabelMap.cast(value, @params) == {:ok, value}
+    end
+
+    test "rejects a value a label cannot hold" do
+      for value <- ["gold tier", String.duplicate("a", 64), "example.com/gold"] do
+        assert LabelMap.cast(%{"tier" => value}, @params) ==
+                 {:error,
+                  [
+                    message: "has an invalid value for key: %{key}",
+                    key: "tier",
+                    validation: :label_map
+                  ]}
+      end
+    end
+
+    test "accepts uppercase in a name and in a value, since only the prefix is a DNS subdomain" do
+      value = %{"Tier" => "Gold", "example.com/Tier" => "Gold"}
+
+      assert LabelMap.cast(value, @params) == {:ok, value}
+    end
+
+    test "rejects an uppercase prefix, unlike an annotation key" do
+      assert {:error, [{:message, "has an invalid key: %{key}"} | _rest]} =
+               LabelMap.cast(%{"Example.com/tier" => "gold"}, @params)
+    end
+
+    test "passes nil through" do
+      assert LabelMap.cast(nil, @params) == {:ok, nil}
+    end
+
+    test "honours a key bound narrower than the label rule" do
+      params = LabelMap.init(max_key_length: 8)
+
+      assert {:error, [{:message, "has a key longer than %{max_length} bytes"} | _rest]} =
+               LabelMap.cast(%{"example.com/tier" => "gold"}, params)
+    end
+
+    test "honours a bound narrower than the label rule" do
+      params = LabelMap.init(max_value_length: 3)
+
+      assert {:error, [{:message, "has a value longer than %{max_length} bytes for key: %{key}"} | _rest]} =
+               LabelMap.cast(%{"tier" => "gold"}, params)
+    end
+  end
+
+  describe "load/3" do
+    test "is lenient, so a row written before this type still reads" do
+      assert LabelMap.load(%{"tier gold" => "gold"}, nil, @params) == {:ok, %{"tier gold" => "gold"}}
+    end
+  end
+
+  describe "dump/3" do
+    test "holds a value to the same rules as cast/2" do
+      assert LabelMap.dump(%{"tier" => "gold"}, nil, @params) == {:ok, %{"tier" => "gold"}}
+      assert LabelMap.dump(%{"tier" => "gold tier"}, nil, @params) == :error
+    end
+  end
+
+  describe "embed_as/2" do
+    test "is :dump, so a nested field is validated on write" do
+      assert LabelMap.embed_as(:json, @params) == :dump
+    end
+  end
+
+  describe "schema field declarations" do
+    test "a field needs no options to enforce the label rules" do
+      assert {:ok, %WithKubernetesMetadata{labels: %{"tier" => "gold"}}} =
+               WithKubernetesMetadata.new(%{labels: %{"tier" => "gold"}})
+
+      assert {:error, _changeset} = WithKubernetesMetadata.new(%{labels: %{"tier" => "gold tier"}})
+    end
+
+    test "a violation names the label map as its reason" do
+      assert {:error, changeset} = WithKubernetesMetadata.new(%{labels: %{"-tier" => "gold"}})
+
+      assert Trogon.Ecto.Changeset.field_violations(changeset) == [
+               %Trogon.Ecto.FieldViolation{
+                 field: "labels",
+                 reason: :label_map,
+                 message: "has an invalid key: -tier",
+                 template: "has an invalid key: %{key}",
+                 metadata: [key: "-tier"]
+               }
+             ]
+    end
+  end
+end

--- a/apps/trogon_ecto/test/trogon/ecto/migration_test.exs
+++ b/apps/trogon_ecto/test/trogon/ecto/migration_test.exs
@@ -131,7 +131,28 @@ defmodule Trogon.Ecto.MigrationTest do
       assert command == {:alter, table, [{:add, :balance_amount, :integer, []}]}
     end
 
-    test "add_annotations_column/1 adds an :annotations :map column defaulting to \"{}\"", %{
+    test "add_string_map_column/2 adds a :jsonb column defaulting to \"{}\"", %{
+      runner: runner,
+      table: table
+    } do
+      command =
+        MigrationTestSupport.capture_command(runner, table, fn ->
+          Trogon.Ecto.Migration.add_string_map_column(:labels)
+        end)
+
+      assert command == {:alter, table, [{:add, :labels, :jsonb, [default: "{}"]}]}
+    end
+
+    test "add_string_map_column/2 lets caller opts override the default", %{runner: runner, table: table} do
+      command =
+        MigrationTestSupport.capture_command(runner, table, fn ->
+          Trogon.Ecto.Migration.add_string_map_column(:labels, default: nil, null: false)
+        end)
+
+      assert command == {:alter, table, [{:add, :labels, :jsonb, [default: nil, null: false]}]}
+    end
+
+    test "add_annotations_column/1 adds an :annotations :jsonb column defaulting to \"{}\"", %{
       runner: runner,
       table: table
     } do
@@ -140,7 +161,7 @@ defmodule Trogon.Ecto.MigrationTest do
           Trogon.Ecto.Migration.add_annotations_column()
         end)
 
-      assert command == {:alter, table, [{:add, :annotations, :map, [default: "{}"]}]}
+      assert command == {:alter, table, [{:add, :annotations, :jsonb, [default: "{}"]}]}
     end
 
     test "add_annotations_column/1 lets caller opts override the default", %{runner: runner, table: table} do
@@ -149,7 +170,7 @@ defmodule Trogon.Ecto.MigrationTest do
           Trogon.Ecto.Migration.add_annotations_column(default: nil)
         end)
 
-      assert command == {:alter, table, [{:add, :annotations, :map, [default: nil]}]}
+      assert command == {:alter, table, [{:add, :annotations, :jsonb, [default: nil]}]}
     end
 
     test "add_uuid_column/2 adds a :binary_id column", %{runner: runner, table: table} do

--- a/apps/trogon_ecto/test/trogon/ecto/string_map_test.exs
+++ b/apps/trogon_ecto/test/trogon/ecto/string_map_test.exs
@@ -1,0 +1,610 @@
+defmodule Trogon.Ecto.StringMapTest do
+  use ExUnit.Case, async: true
+
+  alias Trogon.Ecto.StringMap
+  alias Trogon.Ecto.TestSupport
+  alias Trogon.Ecto.TestSupport.WithConfiguredStringMap
+  alias Trogon.Ecto.TestSupport.WithStringMap
+
+  doctest StringMap
+
+  @any_params StringMap.init([])
+  @strict_params StringMap.init(key_format: :qualified_name, value_format: :label_value)
+
+  describe "init/1" do
+    test "leaves every rule unconstrained by default" do
+      assert StringMap.init([]) == %{
+               key_format: :any,
+               value_format: :any,
+               max_key_length: :infinity,
+               max_value_length: :infinity,
+               validation: :string_map
+             }
+    end
+
+    test "keeps the given formats" do
+      assert StringMap.init(key_format: :qualified_name, value_format: :label_value) ==
+               %{
+                 key_format: :qualified_name,
+                 value_format: :label_value,
+                 max_key_length: :infinity,
+                 max_value_length: :infinity,
+                 validation: :string_map
+               }
+    end
+
+    test "keeps the case-insensitive key format" do
+      assert StringMap.init(key_format: :qualified_name_ignoring_case) ==
+               %{
+                 key_format: :qualified_name_ignoring_case,
+                 value_format: :any,
+                 max_key_length: :infinity,
+                 max_value_length: :infinity,
+                 validation: :string_map
+               }
+    end
+
+    test "keeps the given bounds" do
+      assert StringMap.init(max_key_length: 32, max_value_length: 4_096) ==
+               %{
+                 key_format: :any,
+                 value_format: :any,
+                 max_key_length: 32,
+                 max_value_length: 4_096,
+                 validation: :string_map
+               }
+    end
+
+    test "accepts the options Ecto passes through from field/3" do
+      assert StringMap.init(field: :labels, schema: WithStringMap, default: %{}) ==
+               %{
+                 key_format: :any,
+                 value_format: :any,
+                 max_key_length: :infinity,
+                 max_value_length: :infinity,
+                 validation: :string_map
+               }
+    end
+
+    test "rejects an unknown option" do
+      assert_raise NimbleOptions.ValidationError, ~r/unknown options \[:key_formats\]/, fn ->
+        StringMap.init(key_formats: :qualified_name)
+      end
+    end
+
+    test "rejects an unknown format" do
+      assert_raise NimbleOptions.ValidationError, ~r/invalid value for :key_format/, fn ->
+        StringMap.init(key_format: :dns_label)
+      end
+
+      assert_raise NimbleOptions.ValidationError, ~r/invalid value for :value_format/, fn ->
+        StringMap.init(value_format: :annotation_value)
+      end
+    end
+
+    test "rejects a bound that is not a positive length" do
+      for bound <- [0, -1, "32", :none] do
+        assert_raise NimbleOptions.ValidationError, ~r/invalid value for :max_key_length/, fn ->
+          StringMap.init(max_key_length: bound)
+        end
+
+        assert_raise NimbleOptions.ValidationError, ~r/invalid value for :max_value_length/, fn ->
+          StringMap.init(max_value_length: bound)
+        end
+      end
+    end
+  end
+
+  describe "type/1" do
+    test "is :map" do
+      assert StringMap.type(@any_params) == :map
+    end
+  end
+
+  describe "cast/2" do
+    test "keeps a map of strings as it was given" do
+      assert StringMap.cast(%{"tier" => "gold", "region" => "eu"}, @any_params) ==
+               {:ok, %{"tier" => "gold", "region" => "eu"}}
+    end
+
+    test "passes an empty map through" do
+      assert StringMap.cast(%{}, @any_params) == {:ok, %{}}
+    end
+
+    test "keeps an empty value, which Kubernetes allows" do
+      assert StringMap.cast(%{"app.kubernetes.io/part-of" => ""}, @strict_params) ==
+               {:ok, %{"app.kubernetes.io/part-of" => ""}}
+    end
+
+    test "passes nil through, since an absent map is not an empty one" do
+      assert StringMap.cast(nil, @any_params) == {:ok, nil}
+    end
+
+    test "rejects a value that is not a map" do
+      for value <- ["tier=gold", 123, :gold, [], [{"a", "b"}], true] do
+        assert StringMap.cast(value, @any_params) == :error
+      end
+    end
+
+    test "rejects a struct, which would otherwise be read as its fields" do
+      for value <- [~U[2024-01-01 00:00:00Z], ~D[2024-01-01], %URI{}] do
+        assert StringMap.cast(value, @any_params) == :error
+      end
+    end
+
+    test "rejects a key that is not a string rather than converting it" do
+      for key <- [:tier, 1, nil, %{"a" => "b"}, ["a"], {:a, :b}] do
+        assert StringMap.cast(%{key => "gold"}, @any_params) ==
+                 {:error, [message: "has a key that is not a string", validation: :string_map]}
+      end
+    end
+
+    test "rejects a value that is not a string rather than converting it" do
+      for value <- [:gold, 3, 1.5, true, false, %{"team" => "core"}, ["a"], {:a, :b}] do
+        assert StringMap.cast(%{"owner" => value}, @any_params) ==
+                 {:error,
+                  [
+                    message: "has a value that is not a string",
+                    key: "owner",
+                    validation: :string_map
+                  ]}
+      end
+    end
+
+    test "rejects a nil value rather than keeping it or emptying it" do
+      assert StringMap.cast(%{"owner" => nil}, @any_params) ==
+               {:error,
+                [
+                  message: "has a value that is not a string",
+                  key: "owner",
+                  validation: :string_map
+                ]}
+    end
+  end
+
+  describe "cast/2 with key_format: :qualified_name" do
+    test "accepts a bare name" do
+      for key <- ["tier", "a", "app.kubernetes.io", "some_key", "some-key", "A1"] do
+        assert StringMap.cast(%{key => "gold"}, @strict_params) == {:ok, %{key => "gold"}}
+      end
+    end
+
+    test "accepts a prefixed name" do
+      for key <- ["app.kubernetes.io/name", "example.com/tier", "a/b"] do
+        assert StringMap.cast(%{key => "gold"}, @strict_params) == {:ok, %{key => "gold"}}
+      end
+    end
+
+    test "accepts a name of 63 bytes and a prefix of 253" do
+      key = "#{String.duplicate("a", 253)}/#{String.duplicate("b", 63)}"
+
+      assert StringMap.cast(%{key => "gold"}, @strict_params) == {:ok, %{key => "gold"}}
+    end
+
+    test "rejects a name longer than 63 bytes" do
+      key = String.duplicate("a", 64)
+
+      assert StringMap.cast(%{key => "gold"}, @strict_params) ==
+               {:error, [message: "has an invalid key: %{key}", key: key, validation: :string_map]}
+    end
+
+    test "rejects a prefix longer than 253 bytes" do
+      key = "#{String.duplicate("a", 254)}/name"
+
+      assert StringMap.cast(%{key => "gold"}, @strict_params) ==
+               {:error, [message: "has an invalid key: %{key}", key: key, validation: :string_map]}
+    end
+
+    test "rejects a key that does not begin and end alphanumeric" do
+      for key <- ["-tier", "tier-", ".tier", "tier.", "_tier", "tier_"] do
+        assert StringMap.cast(%{key => "gold"}, @strict_params) ==
+                 {:error, [message: "has an invalid key: %{key}", key: key, validation: :string_map]}
+      end
+    end
+
+    test "rejects a key holding a character outside the rule" do
+      for key <- ["tier gold", "tier!", "tier:gold", "tiér"] do
+        assert StringMap.cast(%{key => "gold"}, @strict_params) ==
+                 {:error, [message: "has an invalid key: %{key}", key: key, validation: :string_map]}
+      end
+    end
+
+    test "rejects an empty key, with or without a prefix" do
+      for key <- ["", "/name", "example.com/"] do
+        assert StringMap.cast(%{key => "gold"}, @strict_params) ==
+                 {:error, [message: "has an invalid key: %{key}", key: key, validation: :string_map]}
+      end
+    end
+
+    test "rejects a trailing newline anywhere in the key" do
+      for key <- ["tier\n", "example.com/tier\n", "example.com\n/tier"] do
+        assert StringMap.cast(%{key => "gold"}, @strict_params) ==
+                 {:error, [message: "has an invalid key: %{key}", key: key, validation: :string_map]}
+      end
+    end
+
+    test "rejects a second slash" do
+      key = "example.com/a/b"
+
+      assert StringMap.cast(%{key => "gold"}, @strict_params) ==
+               {:error, [message: "has an invalid key: %{key}", key: key, validation: :string_map]}
+    end
+
+    test "rejects an uppercase prefix, which is not a DNS subdomain" do
+      key = "Example.com/tier"
+
+      assert StringMap.cast(%{key => "gold"}, @strict_params) ==
+               {:error, [message: "has an invalid key: %{key}", key: key, validation: :string_map]}
+    end
+
+    test "accepts an uppercase prefix under key_format: :qualified_name_ignoring_case" do
+      params = StringMap.init(key_format: :qualified_name_ignoring_case)
+
+      for key <- ["Example.com/tier", "EXAMPLE.COM/Tier", "example.com/tier"] do
+        assert StringMap.cast(%{key => "gold"}, params) == {:ok, %{key => "gold"}}
+      end
+    end
+
+    test "still rejects a malformed key under key_format: :qualified_name_ignoring_case" do
+      params = StringMap.init(key_format: :qualified_name_ignoring_case)
+
+      for key <- ["-tier", "example.com/a/b", "tier gold", "Tier\n", ""] do
+        assert {:error, _error} = StringMap.cast(%{key => "gold"}, params)
+      end
+    end
+
+    test "leaves the key alone under key_format: :any" do
+      for key <- ["tier gold", "-tier", "example.com/a/b", ""] do
+        assert StringMap.cast(%{key => "gold"}, @any_params) == {:ok, %{key => "gold"}}
+      end
+    end
+  end
+
+  describe "cast/2 with value_format: :label_value" do
+    test "accepts an empty value" do
+      assert StringMap.cast(%{"tier" => ""}, @strict_params) == {:ok, %{"tier" => ""}}
+    end
+
+    test "accepts a value of 63 bytes" do
+      value = String.duplicate("a", 63)
+
+      assert StringMap.cast(%{"tier" => value}, @strict_params) == {:ok, %{"tier" => value}}
+    end
+
+    test "accepts a value holding every character the rule allows" do
+      for value <- ["Gold", "gold_tier", "gold.tier", "gold-tier", "v1.2.3-rc_4", "A1"] do
+        assert StringMap.cast(%{"tier" => value}, @strict_params) == {:ok, %{"tier" => value}}
+      end
+    end
+
+    test "rejects a value longer than 63 bytes" do
+      value = String.duplicate("a", 64)
+
+      assert StringMap.cast(%{"tier" => value}, @strict_params) ==
+               {:error,
+                [
+                  message: "has an invalid value for key: %{key}",
+                  key: "tier",
+                  validation: :string_map
+                ]}
+    end
+
+    test "rejects a value with a trailing newline" do
+      assert StringMap.cast(%{"tier" => "gold\n"}, @strict_params) ==
+               {:error,
+                [
+                  message: "has an invalid value for key: %{key}",
+                  key: "tier",
+                  validation: :string_map
+                ]}
+    end
+
+    test "rejects a value holding a character outside the rule" do
+      for value <- ["gold tier", "gold!", "example.com/gold", "-gold"] do
+        assert StringMap.cast(%{"tier" => value}, @strict_params) ==
+                 {:error,
+                  [
+                    message: "has an invalid value for key: %{key}",
+                    key: "tier",
+                    validation: :string_map
+                  ]}
+      end
+    end
+
+    test "leaves the value alone under value_format: :any, as an annotation does" do
+      params = StringMap.init(key_format: :qualified_name)
+      value = String.duplicate("a", 500)
+
+      assert StringMap.cast(%{"example.com/note" => value}, params) ==
+               {:ok, %{"example.com/note" => value}}
+    end
+  end
+
+  describe "cast/2 with length bounds" do
+    test "accepts a key and a value at the bound" do
+      params = StringMap.init(max_key_length: 4, max_value_length: 4)
+
+      assert StringMap.cast(%{"tier" => "gold"}, params) == {:ok, %{"tier" => "gold"}}
+    end
+
+    test "rejects a key over the bound, keeping it out of the message" do
+      params = StringMap.init(max_key_length: 3)
+
+      assert StringMap.cast(%{"tier" => "gold"}, params) ==
+               {:error,
+                [
+                  message: "has a key longer than %{max_length} bytes",
+                  max_length: 3,
+                  key: "tier",
+                  validation: :string_map
+                ]}
+    end
+
+    test "rejects a value over the bound" do
+      params = StringMap.init(max_value_length: 3)
+
+      assert StringMap.cast(%{"tier" => "gold"}, params) ==
+               {:error,
+                [
+                  message: "has a value longer than %{max_length} bytes for key: %{key}",
+                  max_length: 3,
+                  key: "tier",
+                  validation: :string_map
+                ]}
+    end
+
+    test "counts bytes rather than characters" do
+      params = StringMap.init(max_value_length: 3)
+
+      assert StringMap.cast(%{"tier" => "ä"}, params) == {:ok, %{"tier" => "ä"}}
+
+      assert {:error, _error} = StringMap.cast(%{"tier" => "ääa"}, params)
+    end
+
+    test "bounds the whole key rather than either part of a qualified name" do
+      params = StringMap.init(key_format: :qualified_name, max_key_length: 16)
+
+      assert StringMap.cast(%{"example.com/tier" => "gold"}, params) ==
+               {:ok, %{"example.com/tier" => "gold"}}
+
+      assert {:error, [{:message, "has a key longer than %{max_length} bytes"} | _rest]} =
+               StringMap.cast(%{"example.com/region" => "gold"}, params)
+    end
+
+    test "reports the bound before the format, the narrower rule of the two" do
+      params = StringMap.init(value_format: :label_value, max_value_length: 3)
+
+      assert {:error, [{:message, "has a value longer than %{max_length} bytes for key: %{key}"} | _rest]} =
+               StringMap.cast(%{"tier" => "gold"}, params)
+    end
+
+    test "leaves length alone when unbound" do
+      value = String.duplicate("a", 100_000)
+
+      assert StringMap.cast(%{value => value}, @any_params) == {:ok, %{value => value}}
+    end
+  end
+
+  describe "load/3" do
+    test "loads a map of strings as it was stored" do
+      assert StringMap.load(%{"tier" => "gold"}, nil, @any_params) == {:ok, %{"tier" => "gold"}}
+    end
+
+    test "loads a row written before this type was in place" do
+      assert StringMap.load(%{"tier" => 1, "owner" => nil}, nil, @any_params) ==
+               {:ok, %{"tier" => 1, "owner" => nil}}
+    end
+
+    test "loads a row written before a format was tightened" do
+      assert StringMap.load(%{"tier gold" => "gold"}, nil, @strict_params) ==
+               {:ok, %{"tier gold" => "gold"}}
+    end
+
+    test "loads a map whose keys are not strings" do
+      stored = %{1 => "one", tier: "gold"}
+
+      assert StringMap.load(stored, nil, @strict_params) == {:ok, stored}
+    end
+
+    test "loads nil as nil" do
+      assert StringMap.load(nil, nil, @any_params) == {:ok, nil}
+    end
+
+    test "rejects a value that is not a map" do
+      for value <- ["tier=gold", 123, [], ~U[2024-01-01 00:00:00Z]] do
+        assert StringMap.load(value, nil, @any_params) == :error
+      end
+    end
+  end
+
+  describe "dump/3" do
+    test "dumps a map of strings as it was given" do
+      assert StringMap.dump(%{"tier" => "gold"}, nil, @any_params) == {:ok, %{"tier" => "gold"}}
+    end
+
+    test "dumps an empty map" do
+      assert StringMap.dump(%{}, nil, @any_params) == {:ok, %{}}
+    end
+
+    test "dumps nil as nil" do
+      assert StringMap.dump(nil, nil, @any_params) == {:ok, nil}
+    end
+
+    test "refuses to convert on the way out" do
+      for value <- [%{tier: "gold"}, %{"tier" => 1}, %{"tier" => nil}] do
+        assert StringMap.dump(value, nil, @any_params) == :error
+      end
+    end
+
+    test "holds a value to the same format as cast/2" do
+      assert StringMap.dump(%{"tier gold" => "gold"}, nil, @strict_params) == :error
+      assert StringMap.dump(%{"tier" => "gold tier"}, nil, @strict_params) == :error
+    end
+
+    test "refuses to write back a legacy row that load/3 accepted" do
+      legacy = %{"tier" => 1}
+
+      assert StringMap.load(legacy, nil, @any_params) == {:ok, legacy}
+      assert StringMap.dump(legacy, nil, @any_params) == :error
+    end
+
+    test "rejects a value that is not a map" do
+      for value <- ["tier=gold", 123, [], ~U[2024-01-01 00:00:00Z]] do
+        assert StringMap.dump(value, nil, @any_params) == :error
+      end
+    end
+  end
+
+  describe "round trip" do
+    test "a cast value round-trips exactly" do
+      for value <- [%{"tier" => "gold", "replicas" => "2"}, %{"a" => ""}, %{}] do
+        assert {:ok, cast} = StringMap.cast(value, @strict_params)
+        assert {:ok, dumped} = StringMap.dump(cast, nil, @strict_params)
+        assert {:ok, ^cast} = StringMap.load(dumped, nil, @strict_params)
+      end
+    end
+  end
+
+  describe "schema field declarations" do
+    test "a field takes a map of strings" do
+      assert {:ok, %WithStringMap{labels: %{"tier" => "gold"}}} =
+               WithStringMap.new(%{labels: %{"tier" => "gold"}})
+    end
+
+    test "an absent field stays nil" do
+      assert {:ok, %WithStringMap{labels: nil}} = WithStringMap.new(%{})
+    end
+
+    test "a field reports why it was rejected" do
+      assert {:error, changeset} = WithStringMap.new(%{labels: %{"owner" => %{"team" => "core"}}})
+
+      assert TestSupport.errors_on(changeset) == %{
+               labels: ["has a value that is not a string"]
+             }
+    end
+
+    test "a field carries its own format" do
+      attrs = %{labels: %{"tier" => "gold tier"}, annotations: %{"tier" => "gold tier"}}
+
+      assert {:error, changeset} = WithConfiguredStringMap.new(attrs)
+
+      assert TestSupport.errors_on(changeset) == %{
+               labels: ["has an invalid value for key: tier"]
+             }
+    end
+
+    test "an annotation takes a value a label would not" do
+      attrs = %{annotations: %{"example.com/note" => "a longer sentence, with punctuation."}}
+
+      assert {:ok, %WithConfiguredStringMap{}} = WithConfiguredStringMap.new(attrs)
+    end
+
+    test "the rejection reports as its own violation reason" do
+      assert {:error, changeset} = WithStringMap.new(%{labels: %{"owner" => nil}})
+
+      assert Trogon.Ecto.Changeset.field_violations(changeset) == [
+               %Trogon.Ecto.FieldViolation{
+                 field: "labels",
+                 reason: :string_map,
+                 message: "has a value that is not a string",
+                 template: "has a value that is not a string",
+                 metadata: [key: "owner"]
+               }
+             ]
+    end
+
+    test "a field given something that is not a map reports as a cast failure" do
+      assert {:error, changeset} = WithStringMap.new(%{labels: "tier=gold"})
+
+      assert Trogon.Ecto.Changeset.field_violations(changeset) == [
+               %Trogon.Ecto.FieldViolation{
+                 field: "labels",
+                 reason: :cast,
+                 message: "is invalid",
+                 template: "is invalid",
+                 metadata: []
+               }
+             ]
+    end
+
+    test "a field with several bad entries reports one violation, not one per entry" do
+      attrs = %{labels: %{"tier gold" => "gold", "-owner" => "core", "region" => "us east"}}
+
+      assert {:error, changeset} = WithConfiguredStringMap.new(attrs)
+      assert [%Trogon.Ecto.FieldViolation{field: "labels"}] = Trogon.Ecto.Changeset.field_violations(changeset)
+    end
+
+    test "a bound reports the limit it went over" do
+      value = String.duplicate("a", 65)
+
+      assert {:error, changeset} = WithConfiguredStringMap.new(%{annotations: %{"example.com/note" => value}})
+
+      assert Trogon.Ecto.Changeset.field_violations(changeset) == [
+               %Trogon.Ecto.FieldViolation{
+                 field: "annotations",
+                 reason: :string_map,
+                 message: "has a value longer than 64 bytes for key: example.com/note",
+                 template: "has a value longer than %{max_length} bytes for key: %{key}",
+                 metadata: [max_length: 64, key: "example.com/note"]
+               }
+             ]
+    end
+
+    test "the offending key stays out of the template and in the metadata" do
+      assert {:error, changeset} = WithConfiguredStringMap.new(%{labels: %{"-tier" => "gold"}})
+
+      assert Trogon.Ecto.Changeset.field_violations(changeset) == [
+               %Trogon.Ecto.FieldViolation{
+                 field: "labels",
+                 reason: :string_map,
+                 message: "has an invalid key: -tier",
+                 template: "has an invalid key: %{key}",
+                 metadata: [key: "-tier"]
+               }
+             ]
+    end
+  end
+
+  describe "embed_as/2" do
+    test "is :dump for every format" do
+      for format <- [:json, :self] do
+        assert StringMap.embed_as(format, @any_params) == :dump
+      end
+    end
+
+    test "a nested annotation map is dumped as a plain map" do
+      value_object = struct!(WithStringMap, labels: %{"region" => "us_east"})
+
+      assert {:ok, %{labels: %{"region" => "us_east"}}} = WithStringMap.dump(value_object)
+    end
+
+    test "the dumped value object is JSON encodable" do
+      value_object = struct!(WithStringMap, labels: %{"region" => "us_east"})
+      {:ok, dumped} = WithStringMap.dump(value_object)
+
+      assert {:ok, ~s({"labels":{"region":"us_east"}})} = Jason.encode(dumped)
+    end
+
+    test "a nil value survives the round trip" do
+      value_object = struct!(WithStringMap, labels: nil)
+
+      assert {:ok, %{labels: nil}} = WithStringMap.dump(value_object)
+    end
+
+    test "a map built with struct!/2 that is not all strings cannot be dumped" do
+      value_object = struct!(WithStringMap, labels: %{"replicas" => 3})
+
+      assert_raise ArgumentError, ~r/cannot dump `%{"replicas" => 3}`/, fn ->
+        WithStringMap.dump(value_object)
+      end
+    end
+
+    test "a map built with struct!/2 that breaks the format cannot be dumped either" do
+      value_object = struct!(WithConfiguredStringMap, labels: %{"-tier" => "gold"})
+
+      assert_raise ArgumentError, ~r/cannot dump/, fn ->
+        WithConfiguredStringMap.dump(value_object)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Labels and annotations are a recurring shape, and Kubernetes already settled what that shape is: `map[string]string`. Taking the model from there means a caller who knows Kubernetes already knows what the field accepts.
- `:map` is too permissive to hold that invariant. A value with no single string form gets in, `nil` becomes an empty string, and absent stops being distinguishable from present-and-empty. Ecto own `{:map, :string}` rejects a non-string value but still lets `nil` through and does not constrain keys.
- Labels and annotations share that shape and nothing else: a label is selected on, so both halves of an entry are constrained, while an annotation is never selected on, so only its key is, and its key is matched case insensitively. Two different rules are two different types, so each one gets its name and the field site stops restating the rule. `Trogon.Ecto.StringMap` stays configurable for a map that is neither.
- What Kubernetes enforces as policy rather than shape, reserved prefixes and total map size, is deliberately left out: a column in your own table has no reason to inherit it. A length bound is offered instead, since an unconstrained value is otherwise as large as the column will hold.
- Declaring the field still left its column to be written by hand, and `jsonb` has to be named rather than inferred, since Ecto `:map` renders as whatever `:postgres_map_type` says and `json` keeps duplicate keys and takes no GIN index.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>