### PR TITLE
feat(trogon_ecto): add repo transaction result helper

### DIFF
--- a/apps/trogon_ecto/lib/trogon/ecto/repo.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/repo.ex
@@ -1,0 +1,48 @@
+defmodule Trogon.Ecto.Repo do
+  @moduledoc """
+  Extends a repo with the transaction helpers this package provides.
+
+      defmodule MyApp.Repo do
+        use Ecto.Repo, otp_app: :my_app, adapter: Ecto.Adapters.Postgres
+        use Trogon.Ecto.Repo
+      end
+
+  What it adds is documented on your own repo, since that is where the functions
+  end up.
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      @doc """
+      Runs an `Ecto.Multi` and reports a failure as the value that failed.
+
+          Ecto.Multi.new()
+          |> Ecto.Multi.insert(:account, account_changeset)
+          |> Ecto.Multi.insert(:profile, profile_changeset)
+          |> MyApp.Repo.transact_result()
+
+      `c:Ecto.Repo.transaction/2` reports a failed multi as
+      `{:error, failed_operation, failed_value, changes_so_far}`. A caller that
+      only wants to render the changeset that failed has to reach into four
+      elements to find it, and a caller handing the result upward has to reshape
+      it before anything expecting `{:ok, _}` or `{:error, _}` can match, which
+      is most things, including `with`.
+
+      `opts` are the options of `c:Ecto.Repo.transaction/2` and mean the same
+      here.
+
+      Use `c:Ecto.Repo.transaction/2` when the operation name is what you need,
+      such as telling two failed inserts apart, since this discards it along
+      with the changes made before the failure.
+      """
+      @spec transact_result(Ecto.Multi.t(), Keyword.t()) ::
+              {:ok, Ecto.Multi.changes()} | {:error, any()}
+      def transact_result(%Ecto.Multi{} = multi, opts \\ []) do
+        case transaction(multi, opts) do
+          {:ok, changes} -> {:ok, changes}
+          {:error, _failed_operation, failed_value, _changes_so_far} -> {:error, failed_value}
+        end
+      end
+    end
+  end
+end

--- a/apps/trogon_ecto/test/support/repo_test_support.ex
+++ b/apps/trogon_ecto/test/support/repo_test_support.ex
@@ -1,0 +1,19 @@
+defmodule Trogon.Ecto.RepoTestSupport do
+  @moduledoc false
+
+  defmodule StubRepo do
+    @moduledoc false
+    use Trogon.Ecto.Repo
+
+    @doc false
+    @spec stub_transaction(term()) :: term()
+    def stub_transaction(result), do: Process.put(__MODULE__, result)
+
+    @doc false
+    @spec transaction(Ecto.Multi.t(), Keyword.t()) :: term()
+    def transaction(%Ecto.Multi{} = multi, opts) do
+      send(self(), {:transaction, multi, opts})
+      Process.get(__MODULE__)
+    end
+  end
+end

--- a/apps/trogon_ecto/test/trogon/ecto/repo_test.exs
+++ b/apps/trogon_ecto/test/trogon/ecto/repo_test.exs
@@ -1,0 +1,59 @@
+defmodule Trogon.Ecto.RepoTest do
+  use ExUnit.Case, async: true
+
+  alias Ecto.Multi
+  alias Trogon.Ecto.RepoTestSupport.StubRepo
+
+  setup do
+    %{multi: Multi.put(Multi.new(), :account, :value)}
+  end
+
+  describe "transact_result/2" do
+    test "passes a success through untouched", %{multi: multi} do
+      StubRepo.stub_transaction({:ok, %{account: :inserted}})
+
+      assert StubRepo.transact_result(multi) == {:ok, %{account: :inserted}}
+    end
+
+    test "passes a success that changed nothing through", %{multi: multi} do
+      StubRepo.stub_transaction({:ok, %{}})
+
+      assert StubRepo.transact_result(multi) == {:ok, %{}}
+    end
+
+    test "keeps only the value that failed", %{multi: multi} do
+      StubRepo.stub_transaction({:error, :account, :too_many, %{profile: :inserted}})
+
+      assert StubRepo.transact_result(multi) == {:error, :too_many}
+    end
+
+    test "keeps a failed changeset intact", %{multi: multi} do
+      changeset = Ecto.Changeset.cast({%{title: nil}, %{title: :string}}, %{title: 1}, [:title])
+      StubRepo.stub_transaction({:error, :account, changeset, %{}})
+
+      assert StubRepo.transact_result(multi) == {:error, changeset}
+    end
+
+    test "hands the multi and the options to the repo", %{multi: multi} do
+      StubRepo.stub_transaction({:ok, %{}})
+
+      StubRepo.transact_result(multi, timeout: 1_000)
+
+      assert_received {:transaction, ^multi, [timeout: 1_000]}
+    end
+
+    test "passes no options when none are given", %{multi: multi} do
+      StubRepo.stub_transaction({:ok, %{}})
+
+      StubRepo.transact_result(multi)
+
+      assert_received {:transaction, ^multi, []}
+    end
+
+    test "takes a multi and nothing else" do
+      for value <- [%{}, fn -> :ok end, {:ok, %{}}] do
+        assert_raise FunctionClauseError, fn -> StubRepo.transact_result(value) end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- A failed `Ecto.Multi` comes back as a four element tuple, so the value a caller wants to render sits behind a shape nothing else in a codebase speaks, and every call site writes the same adapter to reach it.
- It belongs on the repo, because running the transaction is what produces that shape, and because a `Trogon.Ecto.Multi` would take the `Multi` alias away from the `Ecto.Multi` that every caller of it is already building.
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
