### PR TITLE
feat(trogon_ecto): add rounded average query helper

### DIFF
--- a/apps/trogon_ecto/lib/trogon/ecto/query.ex
+++ b/apps/trogon_ecto/lib/trogon/ecto/query.ex
@@ -1,0 +1,37 @@
+defmodule Trogon.Ecto.Query do
+  @moduledoc """
+  Query macros that push computation into the database.
+
+  Import alongside `Ecto.Query`:
+
+      import Ecto.Query
+      import Trogon.Ecto.Query
+
+  These macros expand to `Ecto.Query.API.fragment/1` calls, so they can only be
+  used inside a query expression.
+  """
+
+  @doc """
+  Averages a field and rounds the result to `precision` decimal places in the
+  database.
+
+      from(m in Measurement,
+        group_by: m.sensor_id,
+        select: %{sensor_id: m.sensor_id, average: rounded_avg(m.value, 2)}
+      )
+
+  The average is cast to `numeric` before being rounded, because PostgreSQL only
+  defines two argument `ROUND` for `numeric`, while averaging a `:float` column
+  gives `double precision`. Without the cast the query fails at run time with
+  `function round(double precision, integer) does not exist`.
+
+  The result is a `numeric`, so it loads as a `Decimal` whatever the field's own
+  type is. A group whose values are all `NULL` averages to `NULL`, which loads as
+  `nil` rather than as a zero.
+  """
+  defmacro rounded_avg(field, precision) do
+    quote do
+      fragment("ROUND(CAST(AVG(?) AS numeric), ?)", unquote(field), unquote(precision))
+    end
+  end
+end

--- a/apps/trogon_ecto/test/trogon/ecto/query_test.exs
+++ b/apps/trogon_ecto/test/trogon/ecto/query_test.exs
@@ -1,0 +1,31 @@
+defmodule Trogon.Ecto.QueryTest do
+  use ExUnit.Case, async: true
+
+  import Ecto.Query
+  import Trogon.Ecto.Query
+
+  describe "rounded_avg/2" do
+    test "builds the fragment around the field and the precision" do
+      query =
+        from(m in "measurements",
+          group_by: m.sensor_id,
+          select: %{sensor_id: m.sensor_id, average: rounded_avg(m.value, 2)}
+        )
+
+      assert inspect(query) =~ ~s|fragment("ROUND(CAST(AVG(?) AS numeric), ?)", m0.value, 2)|
+    end
+
+    test "takes a precision from a bound variable" do
+      precision = 3
+      query = from(m in "measurements", select: rounded_avg(m.value, ^precision))
+
+      assert inspect(query) =~ ~s|fragment("ROUND(CAST(AVG(?) AS numeric), ?)", m0.value, ^3)|
+    end
+
+    test "can be used outside of a select" do
+      query = from(m in "measurements", group_by: m.sensor_id, having: rounded_avg(m.value, 1) > 4.5)
+
+      assert inspect(query) =~ ~s|fragment("ROUND(CAST(AVG(?) AS numeric), ?)", m0.value, 1) > 4.5|
+    end
+  end
+end


### PR DESCRIPTION
- Rounding an average belongs in the query, because otherwise float precision from the database leaks into application code and the same fragment gets retyped at every call site.
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
