### PR TITLE
feat(trogon_proto): derive environment values from the declared pipeline

### DIFF
--- a/apps/trogon_proto/buf.gen.yaml
+++ b/apps/trogon_proto/buf.gen.yaml
@@ -3,7 +3,7 @@ clean: true
 managed:
   enabled: true
 inputs:
-  - module: buf.build/trogonstack/trogon-proto:v0.13.1
+  - module: buf.build/trogonstack/trogon-proto:v0.17.0
 plugins:
   - local: protoc-gen-elixir
     out: lib/__generated__

--- a/apps/trogon_proto/lib/__generated__/trogon/actor/v1alpha1/actor.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/actor/v1alpha1/actor.pb.ex
@@ -1,0 +1,112 @@
+defmodule TrogonProto.Actor.V1Alpha1.ActorId do
+  @moduledoc """
+  ActorId is the stable identifier for a domain actor.
+
+  The value should be self-describing within the actor namespace, such as a
+  prefixed id or resource-name-like identifier. Use Actor when consumers need the
+  actor class and local id as separate fields.
+  """
+
+  use Protobuf,
+    full_name: "trogon.actor.v1alpha1.ActorId",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "ActorId",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "value",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "value",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:value, 1, type: :string)
+end
+
+defmodule TrogonProto.Actor.V1Alpha1.Actor do
+  @moduledoc """
+  Actor identifies the domain entity that caused an event or action.
+
+  Use this message in event metadata or event payload fields such as
+  created_by, approved_by, or cancelled_by. The application layer maps
+  authenticated principals or system processes into this domain-facing actor.
+  """
+
+  use Protobuf,
+    full_name: "trogon.actor.v1alpha1.Actor",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Actor",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "type",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "type",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "id",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "id",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:type, 1, type: :string)
+  field(:id, 2, type: :string)
+end

--- a/apps/trogon_proto/lib/__generated__/trogon/content/v1alpha1/content.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/content/v1alpha1/content.pb.ex
@@ -1,0 +1,75 @@
+defmodule TrogonProto.Content.V1Alpha1.Content do
+  @moduledoc """
+  Content is a self-describing blob whose interpretation is carried by its
+  media type.
+
+  Use Content for "give me whatever" fields where the producer and consumer
+  negotiate the concrete encoding out of band, and protobuf only needs to
+  transport the typed bytes. Prefer explicit domain messages when the schema
+  is known at design time; reach for Content only when the schema is open or
+  pluggable.
+
+  Example usage:
+
+    import "trogon/content/v1alpha1/content.proto";
+
+    message PublishRequest {
+      string subject = 1;
+      trogon.content.v1alpha1.Content body = 2;
+    }
+  """
+
+  use Protobuf,
+    full_name: "trogon.content.v1alpha1.Content",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Content",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "content_type",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "contentType",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "data",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_BYTES,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "data",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:content_type, 1, type: :string, json_name: "contentType")
+  field(:data, 2, type: :bytes)
+end

--- a/apps/trogon_proto/lib/__generated__/trogon/env/v1alpha1/options.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/env/v1alpha1/options.pb.ex
@@ -1,10 +1,154 @@
+defmodule TrogonProto.Env.V1Alpha1.Decode.Base64.Alphabet do
+  @moduledoc """
+  Alphabet selects the RFC 4648 alphabet.
+  """
+
+  use Protobuf,
+    enum: true,
+    full_name: "trogon.env.v1alpha1.Decode.Base64.Alphabet",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.EnumDescriptorProto{
+      name: "Alphabet",
+      value: [
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "ALPHABET_UNSPECIFIED",
+          number: 0,
+          options: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "ALPHABET_STANDARD",
+          number: 1,
+          options: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "ALPHABET_URL_SAFE",
+          number: 2,
+          options: nil,
+          __unknown_fields__: []
+        }
+      ],
+      options: nil,
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:ALPHABET_UNSPECIFIED, 0)
+  field(:ALPHABET_STANDARD, 1)
+  field(:ALPHABET_URL_SAFE, 2)
+end
+
+defmodule TrogonProto.Env.V1Alpha1.Decode.Base64.Padding do
+  @moduledoc """
+  Padding declares whether `=` padding is expected on the input.
+  """
+
+  use Protobuf,
+    enum: true,
+    full_name: "trogon.env.v1alpha1.Decode.Base64.Padding",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.EnumDescriptorProto{
+      name: "Padding",
+      value: [
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "PADDING_UNSPECIFIED",
+          number: 0,
+          options: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "PADDING_REQUIRED",
+          number: 1,
+          options: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "PADDING_ABSENT",
+          number: 2,
+          options: nil,
+          __unknown_fields__: []
+        }
+      ],
+      options: nil,
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:PADDING_UNSPECIFIED, 0)
+  field(:PADDING_REQUIRED, 1)
+  field(:PADDING_ABSENT, 2)
+end
+
+defmodule TrogonProto.Env.V1Alpha1.Split do
+  @moduledoc """
+  Split turns the single environment value into the elements of a repeated
+  field.
+
+  It is the only step that changes how many values are in play, which is why
+  steps before it see the whole environment value and steps after it run once
+  per element.
+  """
+
+  use Protobuf,
+    full_name: "trogon.env.v1alpha1.Split",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Split",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "delimiter",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "delimiter",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:delimiter, 1, type: :string)
+end
+
 defmodule TrogonProto.Env.V1Alpha1.Trim do
   @moduledoc """
-  Trim specifies how to remove leading and trailing characters from each value
-  after splitting by `split_delimiter`. Internal characters are never affected.
+  Trim removes leading and trailing characters from a value. Internal
+  characters are never affected.
 
-  INVARIANT: If `trim` is set (present), exactly one of its oneof fields must be set.
-  An empty `Trim` (with `by` unset) is a schema error and must be rejected.
+  INVARIANT: exactly one of its oneof fields must be set. An empty `Trim`
+  (with `by` unset) is a schema error and must be rejected.
   """
 
   use Protobuf,
@@ -69,6 +213,971 @@ defmodule TrogonProto.Env.V1Alpha1.Trim do
   )
 
   field(:chars, 2, type: :string, oneof: 0)
+end
+
+defmodule TrogonProto.Env.V1Alpha1.Constraints.ByteSize.Range do
+  @moduledoc """
+  Range is an inclusive bound. At least one of `min` or `max` must be set,
+  and when both are set `min` must be less than or equal to `max`.
+  """
+
+  use Protobuf,
+    full_name: "trogon.env.v1alpha1.Constraints.ByteSize.Range",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Range",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "min",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_UINT32,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "min",
+          proto3_optional: true,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "max",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_UINT32,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: 1,
+          json_name: "max",
+          proto3_optional: true,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [
+        %Google.Protobuf.OneofDescriptorProto{name: "_min", options: nil, __unknown_fields__: []},
+        %Google.Protobuf.OneofDescriptorProto{name: "_max", options: nil, __unknown_fields__: []}
+      ],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:min, 1, proto3_optional: true, type: :uint32)
+  field(:max, 2, proto3_optional: true, type: :uint32)
+end
+
+defmodule TrogonProto.Env.V1Alpha1.Constraints.ByteSize do
+  @moduledoc """
+  ByteSize constrains the byte length of a value. For text this is the UTF-8
+  byte length, not the character count.
+
+  Only valid on `bytes` and `string` fields. On any other field type it is a
+  schema error.
+
+  INVARIANT: exactly one `bound` must be set. An empty `ByteSize` satisfies
+  the non-empty `Constraints` rule while declaring no predicate at all, so it
+  is a schema error and must be rejected. Left accepted, a `Decode.accept` of
+  `{byte_size: {}}` would have nothing to select on and generators would
+  diverge on which candidate wins.
+  """
+
+  use Protobuf,
+    full_name: "trogon.env.v1alpha1.Constraints.ByteSize",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "ByteSize",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "exact",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_UINT32,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "exact",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "range",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_MESSAGE,
+          type_name: ".trogon.env.v1alpha1.Constraints.ByteSize.Range",
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "range",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [
+        %Google.Protobuf.DescriptorProto{
+          name: "Range",
+          field: [
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "min",
+              extendee: nil,
+              number: 1,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_UINT32,
+              type_name: nil,
+              default_value: nil,
+              options: nil,
+              oneof_index: 0,
+              json_name: "min",
+              proto3_optional: true,
+              __unknown_fields__: []
+            },
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "max",
+              extendee: nil,
+              number: 2,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_UINT32,
+              type_name: nil,
+              default_value: nil,
+              options: nil,
+              oneof_index: 1,
+              json_name: "max",
+              proto3_optional: true,
+              __unknown_fields__: []
+            }
+          ],
+          nested_type: [],
+          enum_type: [],
+          extension_range: [],
+          extension: [],
+          options: nil,
+          oneof_decl: [
+            %Google.Protobuf.OneofDescriptorProto{
+              name: "_min",
+              options: nil,
+              __unknown_fields__: []
+            },
+            %Google.Protobuf.OneofDescriptorProto{
+              name: "_max",
+              options: nil,
+              __unknown_fields__: []
+            }
+          ],
+          reserved_range: [],
+          reserved_name: [],
+          __unknown_fields__: []
+        }
+      ],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [
+        %Google.Protobuf.OneofDescriptorProto{name: "bound", options: nil, __unknown_fields__: []}
+      ],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  oneof(:bound, 0)
+
+  field(:exact, 1, type: :uint32, oneof: 0)
+  field(:range, 2, type: TrogonProto.Env.V1Alpha1.Constraints.ByteSize.Range, oneof: 0)
+end
+
+defmodule TrogonProto.Env.V1Alpha1.Constraints do
+  @moduledoc """
+  Constraints declares the accepted shape of a value.
+
+  INVARIANT: at least one field must be set. An empty `Constraints` is a schema
+  error and must be rejected.
+  """
+
+  use Protobuf,
+    full_name: "trogon.env.v1alpha1.Constraints",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Constraints",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "byte_size",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_MESSAGE,
+          type_name: ".trogon.env.v1alpha1.Constraints.ByteSize",
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "byteSize",
+          proto3_optional: true,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [
+        %Google.Protobuf.DescriptorProto{
+          name: "ByteSize",
+          field: [
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "exact",
+              extendee: nil,
+              number: 1,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_UINT32,
+              type_name: nil,
+              default_value: nil,
+              options: nil,
+              oneof_index: 0,
+              json_name: "exact",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            },
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "range",
+              extendee: nil,
+              number: 2,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_MESSAGE,
+              type_name: ".trogon.env.v1alpha1.Constraints.ByteSize.Range",
+              default_value: nil,
+              options: nil,
+              oneof_index: 0,
+              json_name: "range",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            }
+          ],
+          nested_type: [
+            %Google.Protobuf.DescriptorProto{
+              name: "Range",
+              field: [
+                %Google.Protobuf.FieldDescriptorProto{
+                  name: "min",
+                  extendee: nil,
+                  number: 1,
+                  label: :LABEL_OPTIONAL,
+                  type: :TYPE_UINT32,
+                  type_name: nil,
+                  default_value: nil,
+                  options: nil,
+                  oneof_index: 0,
+                  json_name: "min",
+                  proto3_optional: true,
+                  __unknown_fields__: []
+                },
+                %Google.Protobuf.FieldDescriptorProto{
+                  name: "max",
+                  extendee: nil,
+                  number: 2,
+                  label: :LABEL_OPTIONAL,
+                  type: :TYPE_UINT32,
+                  type_name: nil,
+                  default_value: nil,
+                  options: nil,
+                  oneof_index: 1,
+                  json_name: "max",
+                  proto3_optional: true,
+                  __unknown_fields__: []
+                }
+              ],
+              nested_type: [],
+              enum_type: [],
+              extension_range: [],
+              extension: [],
+              options: nil,
+              oneof_decl: [
+                %Google.Protobuf.OneofDescriptorProto{
+                  name: "_min",
+                  options: nil,
+                  __unknown_fields__: []
+                },
+                %Google.Protobuf.OneofDescriptorProto{
+                  name: "_max",
+                  options: nil,
+                  __unknown_fields__: []
+                }
+              ],
+              reserved_range: [],
+              reserved_name: [],
+              __unknown_fields__: []
+            }
+          ],
+          enum_type: [],
+          extension_range: [],
+          extension: [],
+          options: nil,
+          oneof_decl: [
+            %Google.Protobuf.OneofDescriptorProto{
+              name: "bound",
+              options: nil,
+              __unknown_fields__: []
+            }
+          ],
+          reserved_range: [],
+          reserved_name: [],
+          __unknown_fields__: []
+        }
+      ],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [
+        %Google.Protobuf.OneofDescriptorProto{
+          name: "_byte_size",
+          options: nil,
+          __unknown_fields__: []
+        }
+      ],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:byte_size, 1,
+    proto3_optional: true,
+    type: TrogonProto.Env.V1Alpha1.Constraints.ByteSize,
+    json_name: "byteSize"
+  )
+end
+
+defmodule TrogonProto.Env.V1Alpha1.Decode.Base64 do
+  @moduledoc """
+  Base64 decodes the value as RFC 4648 base64.
+  """
+
+  use Protobuf,
+    full_name: "trogon.env.v1alpha1.Decode.Base64",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Base64",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "alphabet",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_ENUM,
+          type_name: ".trogon.env.v1alpha1.Decode.Base64.Alphabet",
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "alphabet",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "padding",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_ENUM,
+          type_name: ".trogon.env.v1alpha1.Decode.Base64.Padding",
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "padding",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [
+        %Google.Protobuf.EnumDescriptorProto{
+          name: "Alphabet",
+          value: [
+            %Google.Protobuf.EnumValueDescriptorProto{
+              name: "ALPHABET_UNSPECIFIED",
+              number: 0,
+              options: nil,
+              __unknown_fields__: []
+            },
+            %Google.Protobuf.EnumValueDescriptorProto{
+              name: "ALPHABET_STANDARD",
+              number: 1,
+              options: nil,
+              __unknown_fields__: []
+            },
+            %Google.Protobuf.EnumValueDescriptorProto{
+              name: "ALPHABET_URL_SAFE",
+              number: 2,
+              options: nil,
+              __unknown_fields__: []
+            }
+          ],
+          options: nil,
+          reserved_range: [],
+          reserved_name: [],
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.EnumDescriptorProto{
+          name: "Padding",
+          value: [
+            %Google.Protobuf.EnumValueDescriptorProto{
+              name: "PADDING_UNSPECIFIED",
+              number: 0,
+              options: nil,
+              __unknown_fields__: []
+            },
+            %Google.Protobuf.EnumValueDescriptorProto{
+              name: "PADDING_REQUIRED",
+              number: 1,
+              options: nil,
+              __unknown_fields__: []
+            },
+            %Google.Protobuf.EnumValueDescriptorProto{
+              name: "PADDING_ABSENT",
+              number: 2,
+              options: nil,
+              __unknown_fields__: []
+            }
+          ],
+          options: nil,
+          reserved_range: [],
+          reserved_name: [],
+          __unknown_fields__: []
+        }
+      ],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:alphabet, 1, type: TrogonProto.Env.V1Alpha1.Decode.Base64.Alphabet, enum: true)
+  field(:padding, 2, type: TrogonProto.Env.V1Alpha1.Decode.Base64.Padding, enum: true)
+end
+
+defmodule TrogonProto.Env.V1Alpha1.Decode.Hex do
+  @moduledoc """
+  Hex decodes the value as base16. Both upper and lower case are accepted.
+  """
+
+  use Protobuf,
+    full_name: "trogon.env.v1alpha1.Decode.Hex",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Hex",
+      field: [],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+end
+
+defmodule TrogonProto.Env.V1Alpha1.Decode.Utf8 do
+  @moduledoc """
+  Utf8 takes the value's own bytes with no transformation. It always
+  succeeds, so it is only meaningful as the last candidate.
+  """
+
+  use Protobuf,
+    full_name: "trogon.env.v1alpha1.Decode.Utf8",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Utf8",
+      field: [],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+end
+
+defmodule TrogonProto.Env.V1Alpha1.Decode.Candidate do
+  @moduledoc """
+  Candidate is one way to read the text.
+
+  INVARIANT: exactly one of its oneof fields must be set. An empty
+  `Candidate` (with `as` unset) is a schema error and must be rejected.
+  """
+
+  use Protobuf,
+    full_name: "trogon.env.v1alpha1.Decode.Candidate",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Candidate",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "base64",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_MESSAGE,
+          type_name: ".trogon.env.v1alpha1.Decode.Base64",
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "base64",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "hex",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_MESSAGE,
+          type_name: ".trogon.env.v1alpha1.Decode.Hex",
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "hex",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "utf8",
+          extendee: nil,
+          number: 3,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_MESSAGE,
+          type_name: ".trogon.env.v1alpha1.Decode.Utf8",
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "utf8",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [
+        %Google.Protobuf.OneofDescriptorProto{name: "as", options: nil, __unknown_fields__: []}
+      ],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  oneof(:as, 0)
+
+  field(:base64, 1, type: TrogonProto.Env.V1Alpha1.Decode.Base64, oneof: 0)
+  field(:hex, 2, type: TrogonProto.Env.V1Alpha1.Decode.Hex, oneof: 0)
+  field(:utf8, 3, type: TrogonProto.Env.V1Alpha1.Decode.Utf8, oneof: 0)
+end
+
+defmodule TrogonProto.Env.V1Alpha1.Decode do
+  @moduledoc """
+  Decode turns text into bytes.
+
+  Environment variables are always text, so a `bytes` field needs a declared
+  decoding. Only valid on `bytes` and `string` fields.
+  """
+
+  use Protobuf,
+    full_name: "trogon.env.v1alpha1.Decode",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Decode",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "any_of",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_REPEATED,
+          type: :TYPE_MESSAGE,
+          type_name: ".trogon.env.v1alpha1.Decode.Candidate",
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "anyOf",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "accept",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_MESSAGE,
+          type_name: ".trogon.env.v1alpha1.Constraints",
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "accept",
+          proto3_optional: true,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [
+        %Google.Protobuf.DescriptorProto{
+          name: "Base64",
+          field: [
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "alphabet",
+              extendee: nil,
+              number: 1,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_ENUM,
+              type_name: ".trogon.env.v1alpha1.Decode.Base64.Alphabet",
+              default_value: nil,
+              options: nil,
+              oneof_index: nil,
+              json_name: "alphabet",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            },
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "padding",
+              extendee: nil,
+              number: 2,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_ENUM,
+              type_name: ".trogon.env.v1alpha1.Decode.Base64.Padding",
+              default_value: nil,
+              options: nil,
+              oneof_index: nil,
+              json_name: "padding",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            }
+          ],
+          nested_type: [],
+          enum_type: [
+            %Google.Protobuf.EnumDescriptorProto{
+              name: "Alphabet",
+              value: [
+                %Google.Protobuf.EnumValueDescriptorProto{
+                  name: "ALPHABET_UNSPECIFIED",
+                  number: 0,
+                  options: nil,
+                  __unknown_fields__: []
+                },
+                %Google.Protobuf.EnumValueDescriptorProto{
+                  name: "ALPHABET_STANDARD",
+                  number: 1,
+                  options: nil,
+                  __unknown_fields__: []
+                },
+                %Google.Protobuf.EnumValueDescriptorProto{
+                  name: "ALPHABET_URL_SAFE",
+                  number: 2,
+                  options: nil,
+                  __unknown_fields__: []
+                }
+              ],
+              options: nil,
+              reserved_range: [],
+              reserved_name: [],
+              __unknown_fields__: []
+            },
+            %Google.Protobuf.EnumDescriptorProto{
+              name: "Padding",
+              value: [
+                %Google.Protobuf.EnumValueDescriptorProto{
+                  name: "PADDING_UNSPECIFIED",
+                  number: 0,
+                  options: nil,
+                  __unknown_fields__: []
+                },
+                %Google.Protobuf.EnumValueDescriptorProto{
+                  name: "PADDING_REQUIRED",
+                  number: 1,
+                  options: nil,
+                  __unknown_fields__: []
+                },
+                %Google.Protobuf.EnumValueDescriptorProto{
+                  name: "PADDING_ABSENT",
+                  number: 2,
+                  options: nil,
+                  __unknown_fields__: []
+                }
+              ],
+              options: nil,
+              reserved_range: [],
+              reserved_name: [],
+              __unknown_fields__: []
+            }
+          ],
+          extension_range: [],
+          extension: [],
+          options: nil,
+          oneof_decl: [],
+          reserved_range: [],
+          reserved_name: [],
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.DescriptorProto{
+          name: "Hex",
+          field: [],
+          nested_type: [],
+          enum_type: [],
+          extension_range: [],
+          extension: [],
+          options: nil,
+          oneof_decl: [],
+          reserved_range: [],
+          reserved_name: [],
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.DescriptorProto{
+          name: "Utf8",
+          field: [],
+          nested_type: [],
+          enum_type: [],
+          extension_range: [],
+          extension: [],
+          options: nil,
+          oneof_decl: [],
+          reserved_range: [],
+          reserved_name: [],
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.DescriptorProto{
+          name: "Candidate",
+          field: [
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "base64",
+              extendee: nil,
+              number: 1,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_MESSAGE,
+              type_name: ".trogon.env.v1alpha1.Decode.Base64",
+              default_value: nil,
+              options: nil,
+              oneof_index: 0,
+              json_name: "base64",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            },
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "hex",
+              extendee: nil,
+              number: 2,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_MESSAGE,
+              type_name: ".trogon.env.v1alpha1.Decode.Hex",
+              default_value: nil,
+              options: nil,
+              oneof_index: 0,
+              json_name: "hex",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            },
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "utf8",
+              extendee: nil,
+              number: 3,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_MESSAGE,
+              type_name: ".trogon.env.v1alpha1.Decode.Utf8",
+              default_value: nil,
+              options: nil,
+              oneof_index: 0,
+              json_name: "utf8",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            }
+          ],
+          nested_type: [],
+          enum_type: [],
+          extension_range: [],
+          extension: [],
+          options: nil,
+          oneof_decl: [
+            %Google.Protobuf.OneofDescriptorProto{
+              name: "as",
+              options: nil,
+              __unknown_fields__: []
+            }
+          ],
+          reserved_range: [],
+          reserved_name: [],
+          __unknown_fields__: []
+        }
+      ],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [
+        %Google.Protobuf.OneofDescriptorProto{
+          name: "_accept",
+          options: nil,
+          __unknown_fields__: []
+        }
+      ],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:any_of, 1,
+    repeated: true,
+    type: TrogonProto.Env.V1Alpha1.Decode.Candidate,
+    json_name: "anyOf"
+  )
+
+  field(:accept, 2, proto3_optional: true, type: TrogonProto.Env.V1Alpha1.Constraints)
+end
+
+defmodule TrogonProto.Env.V1Alpha1.Step do
+  @moduledoc """
+  Step is one operation in the pipeline that derives a field value from an
+  environment variable.
+
+  INVARIANT: exactly one of its oneof fields must be set. An empty `Step`
+  (with `op` unset) is a schema error and must be rejected.
+  """
+
+  use Protobuf,
+    full_name: "trogon.env.v1alpha1.Step",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Step",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "split",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_MESSAGE,
+          type_name: ".trogon.env.v1alpha1.Split",
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "split",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "trim",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_MESSAGE,
+          type_name: ".trogon.env.v1alpha1.Trim",
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "trim",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "decode",
+          extendee: nil,
+          number: 3,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_MESSAGE,
+          type_name: ".trogon.env.v1alpha1.Decode",
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "decode",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "require",
+          extendee: nil,
+          number: 4,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_MESSAGE,
+          type_name: ".trogon.env.v1alpha1.Constraints",
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "require",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [
+        %Google.Protobuf.OneofDescriptorProto{name: "op", options: nil, __unknown_fields__: []}
+      ],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  oneof(:op, 0)
+
+  field(:split, 1, type: TrogonProto.Env.V1Alpha1.Split, oneof: 0)
+  field(:trim, 2, type: TrogonProto.Env.V1Alpha1.Trim, oneof: 0)
+  field(:decode, 3, type: TrogonProto.Env.V1Alpha1.Decode, oneof: 0)
+  field(:require, 4, type: TrogonProto.Env.V1Alpha1.Constraints, oneof: 0)
 end
 
 defmodule TrogonProto.Env.V1Alpha1.EnvVarOption.TagsEntry do
@@ -182,6 +1291,20 @@ defmodule TrogonProto.Env.V1Alpha1.EnvVarOption do
           __unknown_fields__: []
         },
         %Google.Protobuf.FieldDescriptorProto{
+          name: "steps",
+          extendee: nil,
+          number: 6,
+          label: :LABEL_REPEATED,
+          type: :TYPE_MESSAGE,
+          type_name: ".trogon.env.v1alpha1.Step",
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "steps",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
           name: "split_delimiter",
           extendee: nil,
           number: 4,
@@ -189,7 +1312,24 @@ defmodule TrogonProto.Env.V1Alpha1.EnvVarOption do
           type: :TYPE_STRING,
           type_name: nil,
           default_value: nil,
-          options: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: true,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: []
+          },
           oneof_index: 1,
           json_name: "splitDelimiter",
           proto3_optional: true,
@@ -203,7 +1343,24 @@ defmodule TrogonProto.Env.V1Alpha1.EnvVarOption do
           type: :TYPE_MESSAGE,
           type_name: ".trogon.env.v1alpha1.Trim",
           default_value: nil,
-          options: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: true,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: []
+          },
           oneof_index: 2,
           json_name: "trim",
           proto3_optional: true,
@@ -303,8 +1460,16 @@ defmodule TrogonProto.Env.V1Alpha1.EnvVarOption do
 
   field(:visibility, 1, type: TrogonProto.Env.V1Alpha1.Visibility, enum: true)
   field(:default_value, 2, proto3_optional: true, type: :string, json_name: "defaultValue")
-  field(:split_delimiter, 4, proto3_optional: true, type: :string, json_name: "splitDelimiter")
-  field(:trim, 5, proto3_optional: true, type: TrogonProto.Env.V1Alpha1.Trim)
+  field(:steps, 6, repeated: true, type: TrogonProto.Env.V1Alpha1.Step)
+
+  field(:split_delimiter, 4,
+    proto3_optional: true,
+    type: :string,
+    json_name: "splitDelimiter",
+    deprecated: true
+  )
+
+  field(:trim, 5, proto3_optional: true, type: TrogonProto.Env.V1Alpha1.Trim, deprecated: true)
   field(:tags, 3, repeated: true, type: TrogonProto.Env.V1Alpha1.EnvVarOption.TagsEntry, map: true)
 end
 

--- a/apps/trogon_proto/lib/__generated__/trogon/hierarchy/v1alpha1/node.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/hierarchy/v1alpha1/node.pb.ex
@@ -1,0 +1,66 @@
+defmodule TrogonProto.Hierarchy.V1Alpha1.NodeId do
+  @moduledoc """
+  NodeId identifies one node of a tenant's hierarchy.
+
+  A node is a position in the tenant's tree that resources attach to. It is
+  untyped on purpose: tenants model their own structure, and words such as
+  "project" or "team" are labels on a node rather than kinds the platform
+  interprets. Policy attaches to a node and applies to everything at or below
+  it, and name resolution starts at a node and walks toward the root.
+
+  Use this message for the `parent` field on any resource that has a position
+  in the tree:
+
+    message Agent {
+      string agent_id = 1;
+      trogon.hierarchy.v1alpha1.NodeId parent = 2;
+    }
+
+  The field is named for its role, `parent`, while the type states what the
+  role points at. Do not spell the field `parent_id`; the id suffix belongs to
+  the type.
+
+  Do not use NodeId for kinship between resources of the same kind, such as a
+  session spawned by a session. Kinship uses the other resource's own id type
+  in a qualified field, `parent_session`.
+  """
+
+  use Protobuf,
+    full_name: "trogon.hierarchy.v1alpha1.NodeId",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "NodeId",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "value",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "value",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:value, 1, type: :string)
+end

--- a/apps/trogon_proto/lib/__generated__/trogon/nats/micro/v1alpha1/options.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon/nats/micro/v1alpha1/options.pb.ex
@@ -1,0 +1,453 @@
+defmodule TrogonProto.Nats.Micro.V1Alpha1.ContentType do
+  @moduledoc """
+  ContentType selects the NATS message Content-Type used by generated clients
+  and handlers.
+  """
+
+  use Protobuf,
+    enum: true,
+    full_name: "trogon.nats.micro.v1alpha1.ContentType",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.EnumDescriptorProto{
+      name: "ContentType",
+      value: [
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "CONTENT_TYPE_UNSPECIFIED",
+          number: 0,
+          options: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "CONTENT_TYPE_PROTOBUF",
+          number: 1,
+          options: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "CONTENT_TYPE_JSON",
+          number: 2,
+          options: nil,
+          __unknown_fields__: []
+        }
+      ],
+      options: nil,
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:CONTENT_TYPE_UNSPECIFIED, 0)
+  field(:CONTENT_TYPE_PROTOBUF, 1)
+  field(:CONTENT_TYPE_JSON, 2)
+end
+
+defmodule TrogonProto.Nats.Micro.V1Alpha1.ServiceOptions.MetadataEntry do
+  use Protobuf,
+    full_name: "trogon.nats.micro.v1alpha1.ServiceOptions.MetadataEntry",
+    map: true,
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "MetadataEntry",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "key",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "key",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "value",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "value",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: %Google.Protobuf.MessageOptions{
+        message_set_wire_format: false,
+        no_standard_descriptor_accessor: false,
+        deprecated: false,
+        map_entry: true,
+        deprecated_legacy_json_field_conflicts: nil,
+        features: nil,
+        uninterpreted_option: [],
+        __pb_extensions__: %{},
+        __unknown_fields__: []
+      },
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:key, 1, type: :string)
+  field(:value, 2, type: :string)
+end
+
+defmodule TrogonProto.Nats.Micro.V1Alpha1.ServiceOptions do
+  @moduledoc """
+  ServiceOptions defines service-level NATS Services metadata.
+  TODO: Enable when generators need explicit service naming controls.
+  optional string endpoint_prefix = 1;
+  optional string name = 2;
+  """
+
+  use Protobuf,
+    full_name: "trogon.nats.micro.v1alpha1.ServiceOptions",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "ServiceOptions",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "version",
+          extendee: nil,
+          number: 3,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "version",
+          proto3_optional: true,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "description",
+          extendee: nil,
+          number: 4,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: 1,
+          json_name: "description",
+          proto3_optional: true,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "metadata",
+          extendee: nil,
+          number: 5,
+          label: :LABEL_REPEATED,
+          type: :TYPE_MESSAGE,
+          type_name: ".trogon.nats.micro.v1alpha1.ServiceOptions.MetadataEntry",
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "metadata",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "content_type",
+          extendee: nil,
+          number: 6,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_ENUM,
+          type_name: ".trogon.nats.micro.v1alpha1.ContentType",
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "contentType",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [
+        %Google.Protobuf.DescriptorProto{
+          name: "MetadataEntry",
+          field: [
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "key",
+              extendee: nil,
+              number: 1,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_STRING,
+              type_name: nil,
+              default_value: nil,
+              options: nil,
+              oneof_index: nil,
+              json_name: "key",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            },
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "value",
+              extendee: nil,
+              number: 2,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_STRING,
+              type_name: nil,
+              default_value: nil,
+              options: nil,
+              oneof_index: nil,
+              json_name: "value",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            }
+          ],
+          nested_type: [],
+          enum_type: [],
+          extension_range: [],
+          extension: [],
+          options: %Google.Protobuf.MessageOptions{
+            message_set_wire_format: false,
+            no_standard_descriptor_accessor: false,
+            deprecated: false,
+            map_entry: true,
+            deprecated_legacy_json_field_conflicts: nil,
+            features: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: []
+          },
+          oneof_decl: [],
+          reserved_range: [],
+          reserved_name: [],
+          __unknown_fields__: []
+        }
+      ],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [
+        %Google.Protobuf.OneofDescriptorProto{
+          name: "_version",
+          options: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.OneofDescriptorProto{
+          name: "_description",
+          options: nil,
+          __unknown_fields__: []
+        }
+      ],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:version, 3, proto3_optional: true, type: :string)
+  field(:description, 4, proto3_optional: true, type: :string)
+
+  field(:metadata, 5,
+    repeated: true,
+    type: TrogonProto.Nats.Micro.V1Alpha1.ServiceOptions.MetadataEntry,
+    map: true
+  )
+
+  field(:content_type, 6,
+    type: TrogonProto.Nats.Micro.V1Alpha1.ContentType,
+    json_name: "contentType",
+    enum: true
+  )
+end
+
+defmodule TrogonProto.Nats.Micro.V1Alpha1.MethodOptions.MetadataEntry do
+  use Protobuf,
+    full_name: "trogon.nats.micro.v1alpha1.MethodOptions.MetadataEntry",
+    map: true,
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "MetadataEntry",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "key",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "key",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "value",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "value",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: %Google.Protobuf.MessageOptions{
+        message_set_wire_format: false,
+        no_standard_descriptor_accessor: false,
+        deprecated: false,
+        map_entry: true,
+        deprecated_legacy_json_field_conflicts: nil,
+        features: nil,
+        uninterpreted_option: [],
+        __pb_extensions__: %{},
+        __unknown_fields__: []
+      },
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:key, 1, type: :string)
+  field(:value, 2, type: :string)
+end
+
+defmodule TrogonProto.Nats.Micro.V1Alpha1.MethodOptions do
+  @moduledoc """
+  MethodOptions defines method-level NATS endpoint metadata.
+  TODO: Enable when generators need explicit endpoint naming controls.
+  optional string endpoint_name = 1;
+  optional string endpoint_subject = 2;
+  """
+
+  use Protobuf,
+    full_name: "trogon.nats.micro.v1alpha1.MethodOptions",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "MethodOptions",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "metadata",
+          extendee: nil,
+          number: 3,
+          label: :LABEL_REPEATED,
+          type: :TYPE_MESSAGE,
+          type_name: ".trogon.nats.micro.v1alpha1.MethodOptions.MetadataEntry",
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "metadata",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [
+        %Google.Protobuf.DescriptorProto{
+          name: "MetadataEntry",
+          field: [
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "key",
+              extendee: nil,
+              number: 1,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_STRING,
+              type_name: nil,
+              default_value: nil,
+              options: nil,
+              oneof_index: nil,
+              json_name: "key",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            },
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "value",
+              extendee: nil,
+              number: 2,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_STRING,
+              type_name: nil,
+              default_value: nil,
+              options: nil,
+              oneof_index: nil,
+              json_name: "value",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            }
+          ],
+          nested_type: [],
+          enum_type: [],
+          extension_range: [],
+          extension: [],
+          options: %Google.Protobuf.MessageOptions{
+            message_set_wire_format: false,
+            no_standard_descriptor_accessor: false,
+            deprecated: false,
+            map_entry: true,
+            deprecated_legacy_json_field_conflicts: nil,
+            features: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: []
+          },
+          oneof_decl: [],
+          reserved_range: [],
+          reserved_name: [],
+          __unknown_fields__: []
+        }
+      ],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:metadata, 3,
+    repeated: true,
+    type: TrogonProto.Nats.Micro.V1Alpha1.MethodOptions.MetadataEntry,
+    map: true
+  )
+end

--- a/apps/trogon_proto/lib/__generated__/trogon_proto/nats/micro/v1_alpha1/pb_extension.pb.ex
+++ b/apps/trogon_proto/lib/__generated__/trogon_proto/nats/micro/v1_alpha1/pb_extension.pb.ex
@@ -1,0 +1,13 @@
+defmodule TrogonProto.Nats.Micro.V1Alpha1.PbExtension do
+  use Protobuf, protoc_gen_elixir_version: "0.16.0"
+
+  extend(Google.Protobuf.ServiceOptions, :service, 870_014,
+    optional: true,
+    type: TrogonProto.Nats.Micro.V1Alpha1.ServiceOptions
+  )
+
+  extend(Google.Protobuf.MethodOptions, :method, 870_015,
+    optional: true,
+    type: TrogonProto.Nats.Micro.V1Alpha1.MethodOptions
+  )
+end

--- a/apps/trogon_proto/lib/trogon/proto/env.ex
+++ b/apps/trogon_proto/lib/trogon/proto/env.ex
@@ -49,12 +49,55 @@ defmodule Trogon.Proto.Env do
       # Secrets are automatically masked when inspecting/logging
       Logger.info(inspect(config))
 
+  ## Steps
+
+  A field may declare an ordered `steps` pipeline. Loading a value is then:
+
+  1. Read the environment variable, or `default_value` when it is absent.
+  2. Run each step in order.
+  3. Cast the result to the field type.
+
+  `split` is the only step that changes how many values are in play. Steps
+  before it see the whole environment value, steps after it run once per
+  element. A non-repeated field has no `split`, so every step sees the single
+  value.
+
+  - `split` - Breaks the value into elements on a delimiter. Repeated fields only.
+  - `trim` - Strips unicode whitespace, or a given set of characters.
+  - `decode` - Reads the text as bytes, choosing among `any_of` candidates
+    (`base64`, `hex`, `utf8`) by which one satisfies `accept`.
+  - `require` - Validates without producing a new value.
+
+  A 32 byte key supplied either base64 encoded or as raw bytes, tolerant of the
+  trailing newline that `$(cat key.b64)` leaves behind:
+
+      bytes token_signing_key = 1 [(trogon.env.v1alpha1.field).env_var = {
+        visibility: VISIBILITY_SECRET
+        steps: [
+          {trim: {unicode_whitespace: {}}},
+          {decode: {
+            any_of: [
+              {base64: {alphabet: ALPHABET_STANDARD, padding: PADDING_REQUIRED}},
+              {utf8: {}}
+            ]
+            accept: {byte_size: {exact: 32}}
+          }}
+        ]
+      }];
+
+  The declared size is what decides which reading of the input is correct, so it
+  is stated once rather than repeated in a following `require` step.
+
+  Failure messages name the field, the variable, the candidates attempted and
+  the observed byte size. They never carry the value itself.
+
   ## Type Conversions
 
   Environment variables are always strings. This module converts them to the
   appropriate Elixir types based on the proto field type:
 
   - `string` - No conversion
+  - `bytes` - No conversion; pair with a `decode` step to accept encoded input
   - `int32`, `int64` - Parsed via `String.to_integer/1`
   - `float`, `double` - Parsed via `Float.parse/1` (accepts both "1.5" and "1")
   - `bool` - Case-insensitive, truthy values: `"true"`, `"1"`, `"yes"`, `"on"`;
@@ -63,7 +106,6 @@ defmodule Trogon.Proto.Env do
   """
 
   alias TrogonProto.Env.V1Alpha1.FieldOptions
-  alias TrogonProto.Env.V1Alpha1.Trim
   alias TrogonProto.Env.V1Alpha1.Visibility
 
   # Visibility codes - UNSPECIFIED (0) and SECRET (2) are both masked in inspect (secure by default)
@@ -76,14 +118,29 @@ defmodule Trogon.Proto.Env do
   defdelegate get_env(name), to: @system_adapter
   defdelegate get_env(name, default), to: @system_adapter
 
+  @type constraint ::
+          {:byte_size, {:exact, non_neg_integer()}}
+          | {:byte_size, {:range, non_neg_integer() | nil, non_neg_integer() | nil}}
+
+  @type decode_candidate ::
+          {:base64, :standard | :url_safe, :required | :absent}
+          | :hex
+          | :utf8
+
+  @type step ::
+          {:split, String.t()}
+          | {:trim, :unicode_whitespace}
+          | {:trim, {:chars, String.t()}}
+          | {:decode, [decode_candidate()], constraint() | nil}
+          | {:require, constraint()}
+
   @type field_config :: %{
           env_var_name: String.t(),
           visibility: non_neg_integer(),
           default_value: String.t() | nil,
           field_type: atom() | {:enum, module()},
           is_repeated: boolean(),
-          split_delimiter: String.t(),
-          trim: Trim.t() | nil
+          steps: [step()]
         }
 
   @doc false
@@ -177,26 +234,143 @@ defmodule Trogon.Proto.Env do
   end
 
   @doc false
-  def convert_field(value, %{field_type: type, is_repeated: is_repeated, split_delimiter: delimiter, trim: trim}) do
+  def convert_field(value, %{field_type: type, steps: steps}) do
     normalized = normalize_type(type)
 
-    if is_repeated && delimiter != "" do
-      value
-      |> String.split(delimiter)
-      |> Enum.map(&trim(&1, trim))
-      |> Enum.reject(&(&1 == ""))
-      |> Enum.map(&to_scalar(&1, normalized))
-    else
-      to_scalar(value, normalized)
+    steps
+    |> Enum.reduce(value, &apply_step/2)
+    |> cast(normalized)
+  end
+
+  defp cast(values, type) when is_list(values), do: Enum.map(values, &to_scalar(&1, type))
+  defp cast(value, type), do: to_scalar(value, type)
+
+  defp apply_step({:split, delimiter}, value) when is_binary(value) do
+    value
+    |> String.split(delimiter)
+    |> drop_empty()
+  end
+
+  defp apply_step({:trim, how}, values) when is_list(values) do
+    values
+    |> Enum.map(&do_trim(&1, how))
+    |> drop_empty()
+  end
+
+  defp apply_step({:trim, how}, value), do: do_trim(value, how)
+
+  defp apply_step({:decode, candidates, accept}, values) when is_list(values) do
+    Enum.map(values, &do_decode(&1, candidates, accept))
+  end
+
+  defp apply_step({:decode, candidates, accept}, value), do: do_decode(value, candidates, accept)
+
+  defp apply_step({:require, constraint}, values) when is_list(values) do
+    Enum.map(values, &do_require(&1, constraint))
+  end
+
+  defp apply_step({:require, constraint}, value), do: do_require(value, constraint)
+
+  # An element can only become empty by being split out or trimmed down, so
+  # those are the only two points that drop empties.
+  defp drop_empty(values), do: Enum.reject(values, &(&1 == ""))
+
+  defp do_trim(value, :unicode_whitespace), do: String.trim(value)
+  defp do_trim(value, {:chars, chars}), do: String.trim(value, chars)
+
+  defp do_decode(text, candidates, accept) do
+    case Enum.find_value(candidates, &accepted_decoding(&1, text, accept)) do
+      {:ok, decoded} -> decoded
+      nil -> raise ArgumentError, no_acceptable_decoding_reason(candidates, text, accept)
     end
   end
 
-  defp trim(value, nil), do: value
-  defp trim(value, %{by: {:unicode_whitespace, _}}), do: String.trim(value)
-  defp trim(value, %{by: {:chars, chars}}), do: String.trim(value, chars)
-  defp trim(value, _), do: value
+  defp accepted_decoding(candidate, text, accept) do
+    with {:ok, decoded} <- decode_candidate(candidate, text),
+         :ok <- check_constraint(decoded, accept) do
+      {:ok, decoded}
+    else
+      _ -> nil
+    end
+  end
+
+  # Base.decode64/2 with padding: false still accepts a padded input, so absent
+  # padding has to be enforced before delegating.
+  defp decode_candidate({:base64, _alphabet, :absent} = candidate, text) do
+    if String.ends_with?(text, "="), do: :error, else: decode_base64(candidate, text)
+  end
+
+  defp decode_candidate({:base64, _alphabet, _padding} = candidate, text), do: decode_base64(candidate, text)
+
+  defp decode_candidate(:hex, text), do: Base.decode16(text, case: :mixed)
+  defp decode_candidate(:utf8, text), do: {:ok, text}
+
+  defp decode_base64({:base64, :standard, padding}, text) do
+    Base.decode64(text, padding: padding == :required)
+  end
+
+  defp decode_base64({:base64, :url_safe, padding}, text) do
+    Base.url_decode64(text, padding: padding == :required)
+  end
+
+  defp check_constraint(_decoded, nil), do: :ok
+
+  defp check_constraint(decoded, {:byte_size, bound}) do
+    if satisfies_byte_size?(byte_size(decoded), bound), do: :ok, else: :error
+  end
+
+  # Names what was attempted and how big each reading came out. The contract
+  # allows the observed byte size but never the value itself.
+  defp no_acceptable_decoding_reason(candidates, text, accept) do
+    attempted = Enum.map_join(candidates, ", ", &candidate_label/1)
+
+    sizes =
+      candidates
+      |> Enum.flat_map(fn candidate ->
+        case decode_candidate(candidate, text) do
+          {:ok, decoded} -> [byte_size(decoded)]
+          :error -> []
+        end
+      end)
+      |> Enum.uniq()
+
+    "no acceptable decoding (attempted: #{attempted}" <>
+      decoded_sizes_clause(sizes) <> expected_clause(accept) <> ")"
+  end
+
+  defp decoded_sizes_clause([]), do: "; nothing decoded"
+  defp decoded_sizes_clause(sizes), do: "; decoded byte sizes: #{Enum.join(sizes, ", ")}"
+
+  defp expected_clause(nil), do: ""
+  defp expected_clause({:byte_size, bound}), do: "; expected #{describe_byte_size(bound)}"
+
+  defp candidate_label({:base64, alphabet, padding}), do: "base64(#{alphabet}, #{padding})"
+  defp candidate_label(:hex), do: "hex"
+  defp candidate_label(:utf8), do: "utf8"
+
+  defp do_require(value, {:byte_size, bound}) do
+    size = byte_size(value)
+
+    if satisfies_byte_size?(size, bound) do
+      value
+    else
+      raise ArgumentError, "byte size #{size} does not satisfy #{describe_byte_size(bound)}"
+    end
+  end
+
+  defp satisfies_byte_size?(size, {:exact, exact}), do: size == exact
+
+  defp satisfies_byte_size?(size, {:range, min, max}) do
+    (is_nil(min) or size >= min) and (is_nil(max) or size <= max)
+  end
+
+  defp describe_byte_size({:exact, exact}), do: "exactly #{exact} bytes"
+  defp describe_byte_size({:range, min, nil}), do: "at least #{min} bytes"
+  defp describe_byte_size({:range, nil, max}), do: "at most #{max} bytes"
+  defp describe_byte_size({:range, min, max}), do: "between #{min} and #{max} bytes"
 
   defp to_scalar(value, :string), do: value
+  defp to_scalar(value, :bytes), do: value
   defp to_scalar(value, :int32), do: parse_int(value, :int32)
   defp to_scalar(value, :int64), do: parse_int(value, :int64)
   defp to_scalar(value, :float), do: parse_float(value)
@@ -225,12 +399,14 @@ defmodule Trogon.Proto.Env do
   end
 
   defp normalize_type(:TYPE_STRING), do: :string
+  defp normalize_type(:TYPE_BYTES), do: :bytes
   defp normalize_type(:TYPE_INT32), do: :int32
   defp normalize_type(:TYPE_INT64), do: :int64
   defp normalize_type(:TYPE_FLOAT), do: :float
   defp normalize_type(:TYPE_DOUBLE), do: :double
   defp normalize_type(:TYPE_BOOL), do: :bool
   defp normalize_type(:string), do: :string
+  defp normalize_type(:bytes), do: :bytes
   defp normalize_type(:int32), do: :int32
   defp normalize_type(:int64), do: :int64
   defp normalize_type(:float), do: :float
@@ -345,38 +521,290 @@ defmodule Trogon.Proto.Env do
 
   defp build_field_config(field_desc, field_type, env_var_option, is_repeated) do
     default_value = env_var_option.default_value
+    steps = build_steps!(field_desc.name, field_type, env_var_option, is_repeated)
 
-    validate_default_value!(field_desc.name, field_type, default_value)
-
-    %{
+    config = %{
       env_var_name: field_name_to_env_var(field_desc.name),
       visibility: visibility_value(env_var_option.visibility),
       default_value: default_value,
       field_type: field_type,
       is_repeated: is_repeated,
-      split_delimiter: env_var_option.split_delimiter || "",
-      trim: env_var_option.trim
+      steps: steps
     }
+
+    validate_default_value!(field_desc.name, field_type, config)
+
+    config
   end
 
-  defp validate_default_value!(_field_name, _field_type, nil), do: :ok
-  defp validate_default_value!(_field_name, _field_type, ""), do: :ok
+  defp build_steps!(field_name, field_type, env_var_option, is_repeated) do
+    case env_var_option.steps do
+      [] ->
+        legacy_steps(env_var_option, is_repeated)
 
-  defp validate_default_value!(field_name, field_type, default_value) do
-    normalized = normalize_type(field_type)
+      steps ->
+        reject_legacy_combination!(field_name, env_var_option)
 
-    case validate_parseable(default_value, normalized) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        raise CompileError,
-          description:
-            "Field #{field_name} has invalid default_value #{inspect(default_value)} for type #{inspect(field_type)}: #{reason}"
+        steps
+        |> Enum.map(&build_step!(field_name, &1))
+        |> tap(&validate_pipeline!(field_name, field_type, is_repeated, &1))
     end
   end
 
+  # The deprecated split_delimiter and trim only ever applied to repeated
+  # fields, so they translate to a pipeline only in that shape.
+  defp legacy_steps(env_var_option, is_repeated) do
+    if is_repeated and has_split_delimiter?(env_var_option) do
+      [{:split, env_var_option.split_delimiter} | legacy_trim_step(env_var_option.trim)]
+    else
+      []
+    end
+  end
+
+  defp legacy_trim_step(nil), do: []
+  defp legacy_trim_step(%{by: {:unicode_whitespace, _}}), do: [{:trim, :unicode_whitespace}]
+  defp legacy_trim_step(%{by: {:chars, chars}}), do: [{:trim, {:chars, chars}}]
+  defp legacy_trim_step(_), do: []
+
+  defp reject_legacy_combination!(field_name, env_var_option) do
+    legacy =
+      [
+        {"split_delimiter", has_split_delimiter?(env_var_option)},
+        {"trim", not is_nil(env_var_option.trim)}
+      ]
+      |> Enum.filter(&elem(&1, 1))
+      |> Enum.map(&elem(&1, 0))
+
+    unless legacy == [] do
+      raise_field_error!(
+        field_name,
+        "declares steps together with the deprecated #{Enum.join(legacy, " and ")}; use steps alone"
+      )
+    end
+  end
+
+  defp build_step!(field_name, %{op: {:split, %{delimiter: delimiter}}}) do
+    if delimiter in [nil, ""] do
+      raise_field_error!(field_name, "has a split step with an empty delimiter")
+    end
+
+    {:split, delimiter}
+  end
+
+  defp build_step!(_field_name, %{op: {:trim, %{by: {:unicode_whitespace, _}}}}) do
+    {:trim, :unicode_whitespace}
+  end
+
+  defp build_step!(field_name, %{op: {:trim, %{by: {:chars, chars}}}}) do
+    if chars in [nil, ""] do
+      raise_field_error!(field_name, "has a trim step with an empty chars set")
+    end
+
+    {:trim, {:chars, chars}}
+  end
+
+  defp build_step!(field_name, %{op: {:trim, _}}) do
+    raise_field_error!(field_name, "has a trim step without a by")
+  end
+
+  defp build_step!(field_name, %{op: {:decode, decode}}) do
+    candidates = build_candidates!(field_name, decode.any_of)
+    accept = build_constraints!(field_name, decode.accept)
+
+    if length(candidates) > 1 and is_nil(accept) do
+      raise_field_error!(field_name, "has a decode step with several candidates but no accept")
+    end
+
+    {:decode, candidates, accept}
+  end
+
+  defp build_step!(field_name, %{op: {:require, constraints}}) do
+    case build_constraints!(field_name, constraints) do
+      nil -> raise_field_error!(field_name, "has an empty require step")
+      constraint -> {:require, constraint}
+    end
+  end
+
+  defp build_step!(field_name, _step) do
+    raise_field_error!(field_name, "has a step without an op")
+  end
+
+  defp build_candidates!(field_name, []) do
+    raise_field_error!(field_name, "has a decode step with no any_of candidates")
+  end
+
+  defp build_candidates!(field_name, any_of) do
+    candidates = Enum.map(any_of, &build_candidate!(field_name, &1))
+
+    kinds = Enum.map(candidates, &candidate_kind/1)
+
+    if length(Enum.uniq(kinds)) != length(kinds) do
+      raise_field_error!(field_name, "has a decode step with repeated candidates")
+    end
+
+    if :utf8 in kinds and List.last(kinds) != :utf8 do
+      raise_field_error!(field_name, "has a decode step where utf8 is not the last candidate")
+    end
+
+    candidates
+  end
+
+  defp build_candidate!(field_name, %{as: {:base64, base64}}) do
+    {:base64, base64_alphabet!(field_name, base64.alphabet), base64_padding!(field_name, base64.padding)}
+  end
+
+  defp build_candidate!(_field_name, %{as: {:hex, _}}), do: :hex
+  defp build_candidate!(_field_name, %{as: {:utf8, _}}), do: :utf8
+
+  defp build_candidate!(field_name, _candidate) do
+    raise_field_error!(field_name, "has a decode candidate without an as")
+  end
+
+  defp candidate_kind({:base64, _alphabet, _padding}), do: :base64
+  defp candidate_kind(kind), do: kind
+
+  defp base64_alphabet!(_field_name, :ALPHABET_STANDARD), do: :standard
+  defp base64_alphabet!(_field_name, :ALPHABET_URL_SAFE), do: :url_safe
+
+  defp base64_alphabet!(field_name, alphabet) do
+    raise_field_error!(field_name, "has a base64 candidate with an undeclared alphabet #{inspect(alphabet)}")
+  end
+
+  defp base64_padding!(_field_name, :PADDING_REQUIRED), do: :required
+  defp base64_padding!(_field_name, :PADDING_ABSENT), do: :absent
+
+  defp base64_padding!(field_name, padding) do
+    raise_field_error!(field_name, "has a base64 candidate with an undeclared padding #{inspect(padding)}")
+  end
+
+  defp build_constraints!(_field_name, nil), do: nil
+
+  defp build_constraints!(field_name, %{byte_size: nil}) do
+    raise_field_error!(field_name, "has empty constraints")
+  end
+
+  defp build_constraints!(field_name, %{byte_size: byte_size}) do
+    {:byte_size, build_byte_size!(field_name, byte_size)}
+  end
+
+  defp build_byte_size!(_field_name, %{bound: {:exact, exact}}), do: {:exact, exact}
+
+  defp build_byte_size!(field_name, %{bound: {:range, %{min: nil, max: nil}}}) do
+    raise_field_error!(field_name, "has a byte_size range without a bound")
+  end
+
+  defp build_byte_size!(field_name, %{bound: {:range, %{min: min, max: max}}}) do
+    if not is_nil(min) and not is_nil(max) and min > max do
+      raise_field_error!(field_name, "has a byte_size range with min #{min} above max #{max}")
+    end
+
+    {:range, min, max}
+  end
+
+  defp build_byte_size!(field_name, _byte_size) do
+    raise_field_error!(field_name, "has a byte_size without a bound")
+  end
+
+  defp validate_pipeline!(field_name, field_type, is_repeated, steps) do
+    validate_split_placement!(field_name, is_repeated, steps)
+    validate_decode_placement!(field_name, field_type, steps)
+    validate_constraint_types!(field_name, field_type, steps)
+  end
+
+  defp validate_split_placement!(field_name, is_repeated, steps) do
+    case Enum.split_while(steps, &(not match?({:split, _}, &1))) do
+      {_before, []} ->
+        :ok
+
+      {[], [_split | rest]} ->
+        unless is_repeated do
+          raise_field_error!(field_name, "has a split step but is not repeated")
+        end
+
+        if Enum.any?(rest, &match?({:split, _}, &1)) do
+          raise_field_error!(field_name, "has more than one split step")
+        end
+
+      {_before, _} ->
+        raise_field_error!(field_name, "has a split step that is not first")
+    end
+  end
+
+  defp validate_decode_placement!(field_name, field_type, steps) do
+    decodes = Enum.count(steps, &match?({:decode, _, _}, &1))
+
+    cond do
+      decodes == 0 ->
+        :ok
+
+      decodes > 1 ->
+        raise_field_error!(field_name, "has more than one decode step")
+
+      not decodable_type?(field_type) ->
+        raise_field_error!(field_name, "has a decode step but type #{inspect(field_type)} is not bytes or string")
+
+      true ->
+        validate_trims_before_decode!(field_name, steps)
+    end
+  end
+
+  defp validate_trims_before_decode!(field_name, steps) do
+    {_before, [_decode | rest]} = Enum.split_while(steps, &(not match?({:decode, _, _}, &1)))
+
+    if Enum.any?(rest, &match?({:trim, _}, &1)) do
+      raise_field_error!(field_name, "has a trim step after its decode step")
+    end
+  end
+
+  defp validate_constraint_types!(field_name, field_type, steps) do
+    constrains_bytes? =
+      Enum.any?(steps, fn
+        {:require, {:byte_size, _}} -> true
+        {:decode, _candidates, {:byte_size, _}} -> true
+        _ -> false
+      end)
+
+    if constrains_bytes? and not decodable_type?(field_type) do
+      raise_field_error!(field_name, "constrains byte_size but type #{inspect(field_type)} is not bytes or string")
+    end
+  end
+
+  defp decodable_type?(field_type) do
+    normalize_type(field_type) in [:bytes, :string]
+  end
+
+  defp raise_field_error!(field_name, description) do
+    raise CompileError, description: "Field #{field_name} #{description}."
+  end
+
+  defp validate_default_value!(_field_name, _field_type, %{default_value: nil}), do: :ok
+  defp validate_default_value!(_field_name, _field_type, %{default_value: ""}), do: :ok
+
+  defp validate_default_value!(field_name, field_type, %{steps: [_ | _]} = config) do
+    convert_field(config.default_value, config)
+    :ok
+  rescue
+    error in [ArgumentError] ->
+      invalid_default!(field_name, field_type, config.default_value, Exception.message(error))
+  end
+
+  defp validate_default_value!(field_name, field_type, %{default_value: default_value}) do
+    normalized = normalize_type(field_type)
+
+    case validate_parseable(default_value, normalized) do
+      :ok -> :ok
+      {:error, reason} -> invalid_default!(field_name, field_type, default_value, reason)
+    end
+  end
+
+  defp invalid_default!(field_name, field_type, default_value, reason) do
+    raise CompileError,
+      description:
+        "Field #{field_name} has invalid default_value #{inspect(default_value)} for type #{inspect(field_type)}: #{reason}"
+  end
+
   defp validate_parseable(_value, :string), do: :ok
+  defp validate_parseable(_value, :bytes), do: :ok
   defp validate_parseable(_value, :bool), do: :ok
   defp validate_parseable(value, {:enum, enum_module}), do: validate_enum_value(value, enum_module)
 
@@ -423,9 +851,9 @@ defmodule Trogon.Proto.Env do
 
     message =
       "Field #{field_desc.name} has env_var extension but unsupported type #{label_str}#{inspect(field_type)}. " <>
-        "Only scalar string, int32, int64, float, double, bool, and enum fields are supported" <>
+        "Only scalar string, bytes, int32, int64, float, double, bool, and enum fields are supported" <>
         if is_repeated do
-          " (repeated fields require split_delimiter)"
+          " (repeated fields require a split step)"
         else
           ""
         end <> "."
@@ -434,22 +862,29 @@ defmodule Trogon.Proto.Env do
   end
 
   defp has_split_delimiter?(%{split_delimiter: delimiter}) do
-    delimiter && delimiter != ""
+    not is_nil(delimiter) and delimiter != ""
   end
 
   defp valid_env_field?(field_type, is_repeated, env_var_option) do
     scalar_supported = supported_env_type?(field_type)
-    repeated_ok = not is_repeated || has_split_delimiter?(env_var_option)
+    repeated_ok = not is_repeated || splits?(env_var_option)
     scalar_supported && repeated_ok
   end
 
+  defp splits?(env_var_option) do
+    has_split_delimiter?(env_var_option) or
+      Enum.any?(env_var_option.steps, &match?(%{op: {:split, _}}, &1))
+  end
+
   defp supported_env_type?(:TYPE_STRING), do: true
+  defp supported_env_type?(:TYPE_BYTES), do: true
   defp supported_env_type?(:TYPE_INT32), do: true
   defp supported_env_type?(:TYPE_INT64), do: true
   defp supported_env_type?(:TYPE_FLOAT), do: true
   defp supported_env_type?(:TYPE_DOUBLE), do: true
   defp supported_env_type?(:TYPE_BOOL), do: true
   defp supported_env_type?(:string), do: true
+  defp supported_env_type?(:bytes), do: true
   defp supported_env_type?(:int32), do: true
   defp supported_env_type?(:int64), do: true
   defp supported_env_type?(:float), do: true

--- a/apps/trogon_proto/test/proto/acme/test_steps.proto
+++ b/apps/trogon_proto/test/proto/acme/test_steps.proto
@@ -1,0 +1,97 @@
+syntax = "proto3";
+
+package acme.test.v1;
+
+import "trogon/env/v1alpha1/options.proto";
+
+message TestSteps {
+  bytes token_signing_key = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_SECRET,
+    steps: [
+      {trim: {unicode_whitespace: {}}},
+      {decode: {
+        any_of: [
+          {base64: {alphabet: ALPHABET_STANDARD, padding: PADDING_REQUIRED}},
+          {utf8: {}}
+        ],
+        accept: {byte_size: {exact: 32}}
+      }}
+    ]
+  }];
+
+  bytes signature = 2 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_SECRET,
+    steps: [
+      {decode: {
+        any_of: [
+          {hex: {}}
+        ]
+      }}
+    ]
+  }];
+
+  string session_id = 3 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT,
+    steps: [
+      {trim: {unicode_whitespace: {}}},
+      {require: {byte_size: {range: {min: 8, max: 16}}}}
+    ]
+  }];
+
+  repeated int32 port_list = 4 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT,
+    steps: [
+      {split: {delimiter: ","}},
+      {trim: {unicode_whitespace: {}}}
+    ]
+  }];
+
+  repeated string tags = 5 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT,
+    steps: [
+      {split: {delimiter: ","}},
+      {trim: {unicode_whitespace: {}}},
+      {trim: {chars: "*"}}
+    ]
+  }];
+}
+
+message TestStepsDefault {
+  bytes token_signing_key = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_SECRET,
+    default_value: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+    steps: [
+      {trim: {unicode_whitespace: {}}},
+      {decode: {
+        any_of: [
+          {base64: {alphabet: ALPHABET_STANDARD, padding: PADDING_REQUIRED}},
+          {utf8: {}}
+        ],
+        accept: {byte_size: {exact: 32}}
+      }}
+    ]
+  }];
+
+  repeated string tags = 2 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT,
+    default_value: "a, b",
+    steps: [
+      {split: {delimiter: ","}},
+      {trim: {unicode_whitespace: {}}}
+    ]
+  }];
+}
+
+message TestStepsUrlSafe {
+  bytes token_signing_key = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_SECRET,
+    steps: [
+      {decode: {
+        any_of: [
+          {base64: {alphabet: ALPHABET_URL_SAFE, padding: PADDING_ABSENT}}
+        ],
+        accept: {byte_size: {range: {min: 16}}}
+      }}
+    ]
+  }];
+}

--- a/apps/trogon_proto/test/proto/acme/test_steps_invalid.proto
+++ b/apps/trogon_proto/test/proto/acme/test_steps_invalid.proto
@@ -1,0 +1,280 @@
+syntax = "proto3";
+
+package acme.test.v1;
+
+import "trogon/env/v1alpha1/options.proto";
+
+// Every message here violates one pipeline invariant and must be rejected at
+// compile time. None of them has a fixture module for that reason.
+
+message TestStepsWithDeprecated {
+  repeated string tags = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT,
+    split_delimiter: ",",
+    steps: [
+      {split: {delimiter: ","}}
+    ]
+  }];
+}
+
+message TestStepsSplitOnScalar {
+  string database_url = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT,
+    steps: [
+      {split: {delimiter: ","}}
+    ]
+  }];
+}
+
+message TestStepsSplitNotFirst {
+  repeated string tags = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT,
+    steps: [
+      {trim: {unicode_whitespace: {}}},
+      {split: {delimiter: ","}}
+    ]
+  }];
+}
+
+message TestStepsEmptyDelimiter {
+  repeated string tags = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT,
+    steps: [
+      {split: {delimiter: ""}}
+    ]
+  }];
+}
+
+message TestStepsDecodeOnInt {
+  int32 port = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT,
+    steps: [
+      {decode: {
+        any_of: [
+          {hex: {}}
+        ]
+      }}
+    ]
+  }];
+}
+
+message TestStepsTrimAfterDecode {
+  bytes token_signing_key = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_SECRET,
+    steps: [
+      {decode: {
+        any_of: [
+          {hex: {}}
+        ]
+      }},
+      {trim: {unicode_whitespace: {}}}
+    ]
+  }];
+}
+
+message TestStepsCandidatesWithoutAccept {
+  bytes token_signing_key = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_SECRET,
+    steps: [
+      {decode: {
+        any_of: [
+          {base64: {alphabet: ALPHABET_STANDARD, padding: PADDING_REQUIRED}},
+          {utf8: {}}
+        ]
+      }}
+    ]
+  }];
+}
+
+message TestStepsUtf8NotLast {
+  bytes token_signing_key = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_SECRET,
+    steps: [
+      {decode: {
+        any_of: [
+          {utf8: {}},
+          {base64: {alphabet: ALPHABET_STANDARD, padding: PADDING_REQUIRED}}
+        ],
+        accept: {byte_size: {exact: 32}}
+      }}
+    ]
+  }];
+}
+
+message TestStepsUnspecifiedAlphabet {
+  bytes token_signing_key = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_SECRET,
+    steps: [
+      {decode: {
+        any_of: [
+          {base64: {padding: PADDING_REQUIRED}}
+        ]
+      }}
+    ]
+  }];
+}
+
+message TestStepsUnspecifiedPadding {
+  bytes token_signing_key = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_SECRET,
+    steps: [
+      {decode: {
+        any_of: [
+          {base64: {alphabet: ALPHABET_STANDARD}}
+        ]
+      }}
+    ]
+  }];
+}
+
+message TestStepsEmptyRequire {
+  string session_id = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT,
+    steps: [
+      {require: {}}
+    ]
+  }];
+}
+
+message TestStepsByteSizeOnInt {
+  int32 port = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT,
+    steps: [
+      {require: {byte_size: {exact: 4}}}
+    ]
+  }];
+}
+
+message TestStepsRangeWithoutBound {
+  string session_id = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT,
+    steps: [
+      {require: {byte_size: {range: {}}}}
+    ]
+  }];
+}
+
+message TestStepsInvertedRange {
+  string session_id = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT,
+    steps: [
+      {require: {byte_size: {range: {min: 16, max: 8}}}}
+    ]
+  }];
+}
+
+message TestStepsInvalidDefault {
+  bytes token_signing_key = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_SECRET,
+    default_value: "not-valid-base64-and-not-32-bytes",
+    steps: [
+      {decode: {
+        any_of: [
+          {base64: {alphabet: ALPHABET_STANDARD, padding: PADDING_REQUIRED}}
+        ],
+        accept: {byte_size: {exact: 32}}
+      }}
+    ]
+  }];
+}
+
+message TestStepsTwoSplits {
+  repeated string tags = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT,
+    steps: [
+      {split: {delimiter: ","}},
+      {split: {delimiter: ";"}}
+    ]
+  }];
+}
+
+message TestStepsTwoDecodes {
+  bytes token_signing_key = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_SECRET,
+    steps: [
+      {decode: {
+        any_of: [
+          {hex: {}}
+        ]
+      }},
+      {decode: {
+        any_of: [
+          {hex: {}}
+        ]
+      }}
+    ]
+  }];
+}
+
+message TestStepsDecodeWithoutCandidates {
+  bytes token_signing_key = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_SECRET,
+    steps: [
+      {decode: {}}
+    ]
+  }];
+}
+
+message TestStepsRepeatedCandidates {
+  bytes token_signing_key = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_SECRET,
+    steps: [
+      {decode: {
+        any_of: [
+          {hex: {}},
+          {hex: {}}
+        ],
+        accept: {byte_size: {exact: 32}}
+      }}
+    ]
+  }];
+}
+
+message TestStepsCandidateWithoutAs {
+  bytes token_signing_key = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_SECRET,
+    steps: [
+      {decode: {
+        any_of: [
+          {}
+        ]
+      }}
+    ]
+  }];
+}
+
+message TestStepsEmptyTrimChars {
+  string session_id = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT,
+    steps: [
+      {trim: {chars: ""}}
+    ]
+  }];
+}
+
+message TestStepsTrimWithoutBy {
+  string session_id = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT,
+    steps: [
+      {trim: {}}
+    ]
+  }];
+}
+
+message TestStepsStepWithoutOp {
+  string session_id = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT,
+    steps: [
+      {}
+    ]
+  }];
+}
+
+message TestStepsByteSizeWithoutBound {
+  string session_id = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT,
+    steps: [
+      {require: {byte_size: {}}}
+    ]
+  }];
+}

--- a/apps/trogon_proto/test/support/env/config_with_steps.ex
+++ b/apps/trogon_proto/test/support/env/config_with_steps.ex
@@ -1,0 +1,3 @@
+defmodule Trogon.Proto.TestSupport.ConfigWithSteps do
+  use Trogon.Proto.Env, message: Acme.Test.V1.TestSteps
+end

--- a/apps/trogon_proto/test/support/env/config_with_steps_default.ex
+++ b/apps/trogon_proto/test/support/env/config_with_steps_default.ex
@@ -1,0 +1,3 @@
+defmodule Trogon.Proto.TestSupport.ConfigWithStepsDefault do
+  use Trogon.Proto.Env, message: Acme.Test.V1.TestStepsDefault
+end

--- a/apps/trogon_proto/test/support/env/config_with_steps_url_safe.ex
+++ b/apps/trogon_proto/test/support/env/config_with_steps_url_safe.ex
@@ -1,0 +1,3 @@
+defmodule Trogon.Proto.TestSupport.ConfigWithStepsUrlSafe do
+  use Trogon.Proto.Env, message: Acme.Test.V1.TestStepsUrlSafe
+end

--- a/apps/trogon_proto/test/support/proto/acme/test_steps.pb.ex
+++ b/apps/trogon_proto/test/support/proto/acme/test_steps.pb.ex
@@ -1,0 +1,358 @@
+defmodule Acme.Test.V1.TestSteps do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestSteps",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestSteps",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "token_signing_key",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_BYTES,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [
+              {870_003, 2,
+               <<10, 30, 8, 2, 50, 4, 18, 2, 10, 0, 50, 20, 26, 18, 10, 6, 10, 4, 8, 1, 16, 1, 10, 2, 26, 0, 18, 4, 10,
+                 2, 8, 32>>}
+            ]
+          },
+          oneof_index: nil,
+          json_name: "tokenSigningKey",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "signature",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_BYTES,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [{870_003, 2, <<10, 10, 8, 2, 50, 6, 26, 4, 10, 2, 18, 0>>}]
+          },
+          oneof_index: nil,
+          json_name: "signature",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "session_id",
+          extendee: nil,
+          number: 3,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [
+              {870_003, 2, <<10, 20, 8, 1, 50, 4, 18, 2, 10, 0, 50, 10, 34, 8, 10, 6, 18, 4, 8, 8, 16, 16>>}
+            ]
+          },
+          oneof_index: nil,
+          json_name: "sessionId",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "port_list",
+          extendee: nil,
+          number: 4,
+          label: :LABEL_REPEATED,
+          type: :TYPE_INT32,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [
+              {870_003, 2, <<10, 15, 8, 1, 50, 5, 10, 3, 10, 1, 44, 50, 4, 18, 2, 10, 0>>}
+            ]
+          },
+          oneof_index: nil,
+          json_name: "portList",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "tags",
+          extendee: nil,
+          number: 5,
+          label: :LABEL_REPEATED,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [
+              {870_003, 2, <<10, 22, 8, 1, 50, 5, 10, 3, 10, 1, 44, 50, 4, 18, 2, 10, 0, 50, 5, 18, 3, 18, 1, 42>>}
+            ]
+          },
+          oneof_index: nil,
+          json_name: "tags",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:token_signing_key, 1, type: :bytes, json_name: "tokenSigningKey", deprecated: false)
+  field(:signature, 2, type: :bytes, deprecated: false)
+  field(:session_id, 3, type: :string, json_name: "sessionId", deprecated: false)
+  field(:port_list, 4, repeated: true, type: :int32, json_name: "portList", deprecated: false)
+  field(:tags, 5, repeated: true, type: :string, deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsDefault do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsDefault",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsDefault",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "token_signing_key",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_BYTES,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [
+              {870_003, 2,
+               <<10, 76, 8, 2, 18, 44, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65,
+                 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 61, 50, 4,
+                 18, 2, 10, 0, 50, 20, 26, 18, 10, 6, 10, 4, 8, 1, 16, 1, 10, 2, 26, 0, 18, 4, 10, 2, 8, 32>>}
+            ]
+          },
+          oneof_index: nil,
+          json_name: "tokenSigningKey",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "tags",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_REPEATED,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [
+              {870_003, 2, <<10, 21, 8, 1, 18, 4, 97, 44, 32, 98, 50, 5, 10, 3, 10, 1, 44, 50, 4, 18, 2, 10, 0>>}
+            ]
+          },
+          oneof_index: nil,
+          json_name: "tags",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:token_signing_key, 1, type: :bytes, json_name: "tokenSigningKey", deprecated: false)
+  field(:tags, 2, repeated: true, type: :string, deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsUrlSafe do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsUrlSafe",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsUrlSafe",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "token_signing_key",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_BYTES,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [
+              {870_003, 2, <<10, 22, 8, 2, 50, 18, 26, 16, 10, 6, 10, 4, 8, 2, 16, 2, 18, 6, 10, 4, 18, 2, 8, 16>>}
+            ]
+          },
+          oneof_index: nil,
+          json_name: "tokenSigningKey",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:token_signing_key, 1, type: :bytes, json_name: "tokenSigningKey", deprecated: false)
+end

--- a/apps/trogon_proto/test/support/proto/acme/test_steps_invalid.pb.ex
+++ b/apps/trogon_proto/test/support/proto/acme/test_steps_invalid.pb.ex
@@ -1,0 +1,1465 @@
+defmodule Acme.Test.V1.TestStepsWithDeprecated do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsWithDeprecated",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsWithDeprecated",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "tags",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_REPEATED,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [
+              {870_003, 2, <<10, 12, 8, 1, 34, 1, 44, 50, 5, 10, 3, 10, 1, 44>>}
+            ]
+          },
+          oneof_index: nil,
+          json_name: "tags",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:tags, 1, repeated: true, type: :string, deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsSplitOnScalar do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsSplitOnScalar",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsSplitOnScalar",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "database_url",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [{870_003, 2, <<10, 9, 8, 1, 50, 5, 10, 3, 10, 1, 44>>}]
+          },
+          oneof_index: nil,
+          json_name: "databaseUrl",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:database_url, 1, type: :string, json_name: "databaseUrl", deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsSplitNotFirst do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsSplitNotFirst",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsSplitNotFirst",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "tags",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_REPEATED,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [
+              {870_003, 2, <<10, 15, 8, 1, 50, 4, 18, 2, 10, 0, 50, 5, 10, 3, 10, 1, 44>>}
+            ]
+          },
+          oneof_index: nil,
+          json_name: "tags",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:tags, 1, repeated: true, type: :string, deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsEmptyDelimiter do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsEmptyDelimiter",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsEmptyDelimiter",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "tags",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_REPEATED,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [{870_003, 2, <<10, 6, 8, 1, 50, 2, 10, 0>>}]
+          },
+          oneof_index: nil,
+          json_name: "tags",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:tags, 1, repeated: true, type: :string, deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsDecodeOnInt do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsDecodeOnInt",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsDecodeOnInt",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "port",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_INT32,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [{870_003, 2, <<10, 10, 8, 1, 50, 6, 26, 4, 10, 2, 18, 0>>}]
+          },
+          oneof_index: nil,
+          json_name: "port",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:port, 1, type: :int32, deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsTrimAfterDecode do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsTrimAfterDecode",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsTrimAfterDecode",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "token_signing_key",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_BYTES,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [
+              {870_003, 2, <<10, 16, 8, 2, 50, 6, 26, 4, 10, 2, 18, 0, 50, 4, 18, 2, 10, 0>>}
+            ]
+          },
+          oneof_index: nil,
+          json_name: "tokenSigningKey",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:token_signing_key, 1, type: :bytes, json_name: "tokenSigningKey", deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsCandidatesWithoutAccept do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsCandidatesWithoutAccept",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsCandidatesWithoutAccept",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "token_signing_key",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_BYTES,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [
+              {870_003, 2, <<10, 18, 8, 2, 50, 14, 26, 12, 10, 6, 10, 4, 8, 1, 16, 1, 10, 2, 26, 0>>}
+            ]
+          },
+          oneof_index: nil,
+          json_name: "tokenSigningKey",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:token_signing_key, 1, type: :bytes, json_name: "tokenSigningKey", deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsUtf8NotLast do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsUtf8NotLast",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsUtf8NotLast",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "token_signing_key",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_BYTES,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [
+              {870_003, 2,
+               <<10, 24, 8, 2, 50, 20, 26, 18, 10, 2, 26, 0, 10, 6, 10, 4, 8, 1, 16, 1, 18, 4, 10, 2, 8, 32>>}
+            ]
+          },
+          oneof_index: nil,
+          json_name: "tokenSigningKey",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:token_signing_key, 1, type: :bytes, json_name: "tokenSigningKey", deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsUnspecifiedAlphabet do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsUnspecifiedAlphabet",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsUnspecifiedAlphabet",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "token_signing_key",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_BYTES,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [
+              {870_003, 2, <<10, 12, 8, 2, 50, 8, 26, 6, 10, 4, 10, 2, 16, 1>>}
+            ]
+          },
+          oneof_index: nil,
+          json_name: "tokenSigningKey",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:token_signing_key, 1, type: :bytes, json_name: "tokenSigningKey", deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsUnspecifiedPadding do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsUnspecifiedPadding",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsUnspecifiedPadding",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "token_signing_key",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_BYTES,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [{870_003, 2, <<10, 12, 8, 2, 50, 8, 26, 6, 10, 4, 10, 2, 8, 1>>}]
+          },
+          oneof_index: nil,
+          json_name: "tokenSigningKey",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:token_signing_key, 1, type: :bytes, json_name: "tokenSigningKey", deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsEmptyRequire do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsEmptyRequire",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsEmptyRequire",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "session_id",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [{870_003, 2, <<10, 6, 8, 1, 50, 2, 34, 0>>}]
+          },
+          oneof_index: nil,
+          json_name: "sessionId",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:session_id, 1, type: :string, json_name: "sessionId", deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsByteSizeOnInt do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsByteSizeOnInt",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsByteSizeOnInt",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "port",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_INT32,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [{870_003, 2, <<10, 10, 8, 1, 50, 6, 34, 4, 10, 2, 8, 4>>}]
+          },
+          oneof_index: nil,
+          json_name: "port",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:port, 1, type: :int32, deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsRangeWithoutBound do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsRangeWithoutBound",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsRangeWithoutBound",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "session_id",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [{870_003, 2, <<10, 10, 8, 1, 50, 6, 34, 4, 10, 2, 18, 0>>}]
+          },
+          oneof_index: nil,
+          json_name: "sessionId",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:session_id, 1, type: :string, json_name: "sessionId", deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsInvertedRange do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsInvertedRange",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsInvertedRange",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "session_id",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [
+              {870_003, 2, <<10, 14, 8, 1, 50, 10, 34, 8, 10, 6, 18, 4, 8, 16, 16, 8>>}
+            ]
+          },
+          oneof_index: nil,
+          json_name: "sessionId",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:session_id, 1, type: :string, json_name: "sessionId", deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsInvalidDefault do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsInvalidDefault",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsInvalidDefault",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "token_signing_key",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_BYTES,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [
+              {870_003, 2,
+               <<10, 55, 8, 2, 18, 33, 110, 111, 116, 45, 118, 97, 108, 105, 100, 45, 98, 97, 115, 101, 54, 52, 45, 97,
+                 110, 100, 45, 110, 111, 116, 45, 51, 50, 45, 98, 121, 116, 101, 115, 50, 16, 26, 14, 10, 6, 10, 4, 8,
+                 1, 16, 1, 18, 4, 10, 2, 8, 32>>}
+            ]
+          },
+          oneof_index: nil,
+          json_name: "tokenSigningKey",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:token_signing_key, 1, type: :bytes, json_name: "tokenSigningKey", deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsTwoSplits do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsTwoSplits",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsTwoSplits",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "tags",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_REPEATED,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [
+              {870_003, 2, <<10, 16, 8, 1, 50, 5, 10, 3, 10, 1, 44, 50, 5, 10, 3, 10, 1, 59>>}
+            ]
+          },
+          oneof_index: nil,
+          json_name: "tags",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:tags, 1, repeated: true, type: :string, deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsTwoDecodes do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsTwoDecodes",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsTwoDecodes",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "token_signing_key",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_BYTES,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [
+              {870_003, 2, <<10, 18, 8, 2, 50, 6, 26, 4, 10, 2, 18, 0, 50, 6, 26, 4, 10, 2, 18, 0>>}
+            ]
+          },
+          oneof_index: nil,
+          json_name: "tokenSigningKey",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:token_signing_key, 1, type: :bytes, json_name: "tokenSigningKey", deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsDecodeWithoutCandidates do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsDecodeWithoutCandidates",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsDecodeWithoutCandidates",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "token_signing_key",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_BYTES,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [{870_003, 2, <<10, 6, 8, 2, 50, 2, 26, 0>>}]
+          },
+          oneof_index: nil,
+          json_name: "tokenSigningKey",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:token_signing_key, 1, type: :bytes, json_name: "tokenSigningKey", deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsRepeatedCandidates do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsRepeatedCandidates",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsRepeatedCandidates",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "token_signing_key",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_BYTES,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [
+              {870_003, 2, <<10, 20, 8, 2, 50, 16, 26, 14, 10, 2, 18, 0, 10, 2, 18, 0, 18, 4, 10, 2, 8, 32>>}
+            ]
+          },
+          oneof_index: nil,
+          json_name: "tokenSigningKey",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:token_signing_key, 1, type: :bytes, json_name: "tokenSigningKey", deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsCandidateWithoutAs do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsCandidateWithoutAs",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsCandidateWithoutAs",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "token_signing_key",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_BYTES,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [{870_003, 2, <<10, 8, 8, 2, 50, 4, 26, 2, 10, 0>>}]
+          },
+          oneof_index: nil,
+          json_name: "tokenSigningKey",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:token_signing_key, 1, type: :bytes, json_name: "tokenSigningKey", deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsEmptyTrimChars do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsEmptyTrimChars",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsEmptyTrimChars",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "session_id",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [{870_003, 2, <<10, 8, 8, 1, 50, 4, 18, 2, 18, 0>>}]
+          },
+          oneof_index: nil,
+          json_name: "sessionId",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:session_id, 1, type: :string, json_name: "sessionId", deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsTrimWithoutBy do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsTrimWithoutBy",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsTrimWithoutBy",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "session_id",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [{870_003, 2, <<10, 6, 8, 1, 50, 2, 18, 0>>}]
+          },
+          oneof_index: nil,
+          json_name: "sessionId",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:session_id, 1, type: :string, json_name: "sessionId", deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsStepWithoutOp do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsStepWithoutOp",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsStepWithoutOp",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "session_id",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [{870_003, 2, <<10, 4, 8, 1, 50, 0>>}]
+          },
+          oneof_index: nil,
+          json_name: "sessionId",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:session_id, 1, type: :string, json_name: "sessionId", deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestStepsByteSizeWithoutBound do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestStepsByteSizeWithoutBound",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestStepsByteSizeWithoutBound",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "session_id",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [{870_003, 2, <<10, 8, 8, 1, 50, 4, 34, 2, 10, 0>>}]
+          },
+          oneof_index: nil,
+          json_name: "sessionId",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:session_id, 1, type: :string, json_name: "sessionId", deprecated: false)
+end

--- a/apps/trogon_proto/test/trogon/proto/env_test.exs
+++ b/apps/trogon_proto/test/trogon/proto/env_test.exs
@@ -6,6 +6,9 @@ defmodule Trogon.Proto.EnvTest do
   alias Trogon.Proto.TestSupport.AllTypesConfig
   alias Trogon.Proto.TestSupport.ConfigWithEnum
   alias Trogon.Proto.TestSupport.ConfigWithRepeated
+  alias Trogon.Proto.TestSupport.ConfigWithSteps
+  alias Trogon.Proto.TestSupport.ConfigWithStepsDefault
+  alias Trogon.Proto.TestSupport.ConfigWithStepsUrlSafe
   alias Trogon.Proto.TestSupport.ConfigWithTrimCustom
   alias Trogon.Proto.TestSupport.ConfigWithTrimUnicode
   alias Trogon.Proto.TestSupport.ConfigWithUnsupported
@@ -15,39 +18,39 @@ defmodule Trogon.Proto.EnvTest do
   # Unit tests for convert_field/2 - tests type conversion with proto atom types
   describe "convert_field/2" do
     test "converts :TYPE_STRING to string (passthrough)" do
-      config = %{field_type: :TYPE_STRING, is_repeated: false, split_delimiter: "", trim: nil}
+      config = %{field_type: :TYPE_STRING, is_repeated: false, steps: []}
 
       assert Env.convert_field("hello world", config) == "hello world"
     end
 
     test "converts :TYPE_INT32 to integer" do
-      config = %{field_type: :TYPE_INT32, is_repeated: false, split_delimiter: "", trim: nil}
+      config = %{field_type: :TYPE_INT32, is_repeated: false, steps: []}
 
       assert Env.convert_field("42", config) == 42
       assert Env.convert_field("-100", config) == -100
     end
 
     test "converts :TYPE_INT64 to integer" do
-      config = %{field_type: :TYPE_INT64, is_repeated: false, split_delimiter: "", trim: nil}
+      config = %{field_type: :TYPE_INT64, is_repeated: false, steps: []}
 
       assert Env.convert_field("9223372036854775807", config) == 9_223_372_036_854_775_807
     end
 
     test "converts :TYPE_FLOAT to float" do
-      config = %{field_type: :TYPE_FLOAT, is_repeated: false, split_delimiter: "", trim: nil}
+      config = %{field_type: :TYPE_FLOAT, is_repeated: false, steps: []}
 
       assert Env.convert_field("3.14", config) == 3.14
       assert Env.convert_field("42", config) == 42.0
     end
 
     test "converts :TYPE_DOUBLE to float" do
-      config = %{field_type: :TYPE_DOUBLE, is_repeated: false, split_delimiter: "", trim: nil}
+      config = %{field_type: :TYPE_DOUBLE, is_repeated: false, steps: []}
 
       assert Env.convert_field("2.718281828", config) == 2.718281828
     end
 
     test "converts :TYPE_BOOL truthy values to true" do
-      config = %{field_type: :TYPE_BOOL, is_repeated: false, split_delimiter: "", trim: nil}
+      config = %{field_type: :TYPE_BOOL, is_repeated: false, steps: []}
 
       assert Env.convert_field("true", config) == true
       assert Env.convert_field("TRUE", config) == true
@@ -60,7 +63,7 @@ defmodule Trogon.Proto.EnvTest do
     end
 
     test "converts :TYPE_BOOL falsy values to false" do
-      config = %{field_type: :TYPE_BOOL, is_repeated: false, split_delimiter: "", trim: nil}
+      config = %{field_type: :TYPE_BOOL, is_repeated: false, steps: []}
 
       assert Env.convert_field("false", config) == false
       assert Env.convert_field("0", config) == false
@@ -70,13 +73,13 @@ defmodule Trogon.Proto.EnvTest do
     end
 
     test "handles repeated :TYPE_STRING with split_delimiter" do
-      config = %{field_type: :TYPE_STRING, is_repeated: true, split_delimiter: ",", trim: nil}
+      config = %{field_type: :TYPE_STRING, is_repeated: true, steps: [{:split, ","}]}
 
       assert Env.convert_field("a,b,c", config) == ["a", "b", "c"]
     end
 
     test "handles repeated :TYPE_INT32 with split_delimiter" do
-      config = %{field_type: :TYPE_INT32, is_repeated: true, split_delimiter: ",", trim: nil}
+      config = %{field_type: :TYPE_INT32, is_repeated: true, steps: [{:split, ","}]}
 
       assert Env.convert_field("1,2,3", config) == [1, 2, 3]
     end
@@ -85,8 +88,7 @@ defmodule Trogon.Proto.EnvTest do
       config = %{
         field_type: :TYPE_STRING,
         is_repeated: true,
-        split_delimiter: ",",
-        trim: %{by: {:unicode_whitespace, %{}}}
+        steps: [{:split, ","}, {:trim, :unicode_whitespace}]
       }
 
       assert Env.convert_field("  a  ,  b  ,  c  ", config) == ["a", "b", "c"]
@@ -96,21 +98,20 @@ defmodule Trogon.Proto.EnvTest do
       config = %{
         field_type: :TYPE_STRING,
         is_repeated: true,
-        split_delimiter: ",",
-        trim: %{by: {:chars, "*"}}
+        steps: [{:split, ","}, {:trim, {:chars, "*"}}]
       }
 
       assert Env.convert_field("*a*,*b*,*c*", config) == ["a", "b", "c"]
     end
 
     test "filters empty strings from repeated fields" do
-      config = %{field_type: :TYPE_STRING, is_repeated: true, split_delimiter: ",", trim: nil}
+      config = %{field_type: :TYPE_STRING, is_repeated: true, steps: [{:split, ","}]}
 
       assert Env.convert_field("a,,b,", config) == ["a", "b"]
     end
 
     test "raises ArgumentError for invalid float" do
-      config = %{field_type: :TYPE_FLOAT, is_repeated: false, split_delimiter: "", trim: nil}
+      config = %{field_type: :TYPE_FLOAT, is_repeated: false, steps: []}
 
       error =
         assert_raise ArgumentError, fn ->
@@ -121,13 +122,13 @@ defmodule Trogon.Proto.EnvTest do
     end
 
     test "converts enum names to protobuf enum atoms" do
-      config = %{field_type: {:enum, Acme.Test.V1.LogLevel}, is_repeated: false, split_delimiter: "", trim: nil}
+      config = %{field_type: {:enum, Acme.Test.V1.LogLevel}, is_repeated: false, steps: []}
 
       assert Env.convert_field("LOG_LEVEL_DEBUG", config) == :LOG_LEVEL_DEBUG
     end
 
     test "raises ArgumentError for invalid enum names" do
-      config = %{field_type: {:enum, Acme.Test.V1.LogLevel}, is_repeated: false, split_delimiter: "", trim: nil}
+      config = %{field_type: {:enum, Acme.Test.V1.LogLevel}, is_repeated: false, steps: []}
 
       error =
         assert_raise ArgumentError, fn ->
@@ -139,7 +140,7 @@ defmodule Trogon.Proto.EnvTest do
     end
 
     test "does not treat numeric strings as enum values" do
-      config = %{field_type: {:enum, Acme.Test.V1.LogLevel}, is_repeated: false, split_delimiter: "", trim: nil}
+      config = %{field_type: {:enum, Acme.Test.V1.LogLevel}, is_repeated: false, steps: []}
 
       error =
         assert_raise ArgumentError, fn ->
@@ -764,6 +765,193 @@ defmodule Trogon.Proto.EnvTest do
       assert_raise CompileError, ~r/Field log_level has invalid default_value "debug"/, fn ->
         Code.compile_quoted(quoted)
       end
+    end
+  end
+
+  describe "steps pipeline" do
+    @raw_key String.duplicate("k", 32)
+
+    defp steps_env(overrides) do
+      Map.merge(
+        %{
+          "TOKEN_SIGNING_KEY" => Base.encode64(@raw_key),
+          "SIGNATURE" => "DEADBEEF",
+          "SESSION_ID" => "abcdefgh",
+          "PORT_LIST" => "8080",
+          "TAGS" => "foo"
+        },
+        overrides
+      )
+    end
+
+    test "decodes a base64 value into bytes" do
+      TestSupport.stub_system_env(steps_env(%{}))
+
+      assert ConfigWithSteps.from_env!().env.token_signing_key == @raw_key
+    end
+
+    test "trims before decoding so a trailing newline is tolerated" do
+      TestSupport.stub_system_env(steps_env(%{"TOKEN_SIGNING_KEY" => "  #{Base.encode64(@raw_key)}\n"}))
+
+      assert ConfigWithSteps.from_env!().env.token_signing_key == @raw_key
+    end
+
+    test "falls back to utf8 when base64 does not satisfy accept" do
+      TestSupport.stub_system_env(steps_env(%{"TOKEN_SIGNING_KEY" => @raw_key}))
+
+      assert ConfigWithSteps.from_env!().env.token_signing_key == @raw_key
+    end
+
+    test "rejects a value no candidate decodes to an acceptable size" do
+      TestSupport.stub_system_env(steps_env(%{"TOKEN_SIGNING_KEY" => Base.encode64("too short")}))
+
+      assert {:error, error} = ConfigWithSteps.from_env()
+
+      assert [%{env_var: "TOKEN_SIGNING_KEY", field: :token_signing_key, reason: {:invalid, reason}}] = error.errors
+
+      assert reason ==
+               "no acceptable decoding (attempted: base64(standard, required), utf8; " <>
+                 "decoded byte sizes: 9, 12; expected exactly 32 bytes)"
+    end
+
+    test "never repeats the value in a decode failure" do
+      secret = Base.encode64("too short")
+      TestSupport.stub_system_env(steps_env(%{"TOKEN_SIGNING_KEY" => secret}))
+
+      assert {:error, error} = ConfigWithSteps.from_env()
+
+      refute Exception.message(error) =~ secret
+    end
+
+    test "decodes hex in either case" do
+      TestSupport.stub_system_env(steps_env(%{"SIGNATURE" => "deadbeef"}))
+
+      assert ConfigWithSteps.from_env!().env.signature == <<0xDE, 0xAD, 0xBE, 0xEF>>
+    end
+
+    test "rejects hex that is not hex" do
+      TestSupport.stub_system_env(steps_env(%{"SIGNATURE" => "nothex!!"}))
+
+      assert {:error, error} = ConfigWithSteps.from_env()
+
+      assert [%{field: :signature, reason: {:invalid, reason}}] = error.errors
+      assert reason == "no acceptable decoding (attempted: hex; nothing decoded)"
+    end
+
+    test "applies a require step to a trimmed value" do
+      TestSupport.stub_system_env(steps_env(%{"SESSION_ID" => "  abcdefgh  "}))
+
+      assert ConfigWithSteps.from_env!().env.session_id == "abcdefgh"
+    end
+
+    test "rejects a value outside the required byte size range" do
+      TestSupport.stub_system_env(steps_env(%{"SESSION_ID" => "abc"}))
+
+      assert {:error, error} = ConfigWithSteps.from_env()
+
+      assert [%{field: :session_id, reason: {:invalid, reason}}] = error.errors
+      assert reason == "byte size 3 does not satisfy between 8 and 16 bytes"
+    end
+
+    test "splits and trims repeated integers" do
+      TestSupport.stub_system_env(steps_env(%{"PORT_LIST" => " 8080, 9000 ,3000 "}))
+
+      assert ConfigWithSteps.from_env!().env.port_list == [8080, 9000, 3000]
+    end
+
+    test "applies consecutive trims to every element and drops the emptied ones" do
+      TestSupport.stub_system_env(steps_env(%{"TAGS" => " *foo* , *bar*,**, "}))
+
+      assert ConfigWithSteps.from_env!().env.tags == ["foo", "bar"]
+    end
+
+    test "runs default_value through the pipeline" do
+      TestSupport.stub_system_env(%{})
+
+      config = ConfigWithStepsDefault.from_env!()
+
+      assert config.env.token_signing_key == <<0::256>>
+      assert config.env.tags == ["a", "b"]
+    end
+
+    test "rejects a padded value when the candidate declares padding absent" do
+      raw = String.duplicate(<<0xFF, 0xFE>>, 8)
+      TestSupport.stub_system_env(%{"TOKEN_SIGNING_KEY" => Base.url_encode64(raw, padding: true)})
+
+      assert {:error, error} = ConfigWithStepsUrlSafe.from_env()
+
+      assert [%{field: :token_signing_key, reason: {:invalid, reason}}] = error.errors
+
+      assert reason ==
+               "no acceptable decoding (attempted: base64(url_safe, absent); nothing decoded; expected at least 16 bytes)"
+    end
+
+    test "decodes url safe base64 without padding" do
+      raw = String.duplicate(<<0xFF, 0xFE>>, 8)
+      TestSupport.stub_system_env(%{"TOKEN_SIGNING_KEY" => Base.url_encode64(raw, padding: false)})
+
+      assert ConfigWithStepsUrlSafe.from_env!().env.token_signing_key == raw
+    end
+  end
+
+  describe "steps pipeline schema validation" do
+    for {message, description, expected} <- [
+          {Acme.Test.V1.TestStepsWithDeprecated, "steps combined with deprecated fields",
+           "declares steps together with the deprecated split_delimiter"},
+          {Acme.Test.V1.TestStepsSplitOnScalar, "split on a non repeated field",
+           "has a split step but is not repeated"},
+          {Acme.Test.V1.TestStepsSplitNotFirst, "split that is not first", "has a split step that is not first"},
+          {Acme.Test.V1.TestStepsEmptyDelimiter, "empty split delimiter", "has a split step with an empty delimiter"},
+          {Acme.Test.V1.TestStepsDecodeOnInt, "decode on a numeric field",
+           "has a decode step but type .* is not bytes or string"},
+          {Acme.Test.V1.TestStepsTrimAfterDecode, "trim after decode", "has a trim step after its decode step"},
+          {Acme.Test.V1.TestStepsCandidatesWithoutAccept, "several candidates without accept",
+           "has a decode step with several candidates but no accept"},
+          {Acme.Test.V1.TestStepsUtf8NotLast, "utf8 that is not last",
+           "has a decode step where utf8 is not the last candidate"},
+          {Acme.Test.V1.TestStepsUnspecifiedAlphabet, "unspecified base64 alphabet",
+           "has a base64 candidate with an undeclared alphabet"},
+          {Acme.Test.V1.TestStepsUnspecifiedPadding, "unspecified base64 padding",
+           "has a base64 candidate with an undeclared padding"},
+          {Acme.Test.V1.TestStepsEmptyRequire, "empty require", "has empty constraints"},
+          {Acme.Test.V1.TestStepsByteSizeOnInt, "byte_size on a numeric field",
+           "constrains byte_size but type .* is not bytes or string"},
+          {Acme.Test.V1.TestStepsRangeWithoutBound, "byte_size range without a bound",
+           "has a byte_size range without a bound"},
+          {Acme.Test.V1.TestStepsInvertedRange, "byte_size range with min above max",
+           "has a byte_size range with min 16 above max 8"},
+          {Acme.Test.V1.TestStepsInvalidDefault, "a default the pipeline rejects",
+           "has invalid default_value .* no acceptable decoding"},
+          {Acme.Test.V1.TestStepsTwoSplits, "more than one split", "has more than one split step"},
+          {Acme.Test.V1.TestStepsTwoDecodes, "more than one decode", "has more than one decode step"},
+          {Acme.Test.V1.TestStepsDecodeWithoutCandidates, "decode without candidates",
+           "has a decode step with no any_of candidates"},
+          {Acme.Test.V1.TestStepsRepeatedCandidates, "repeated decode candidates",
+           "has a decode step with repeated candidates"},
+          {Acme.Test.V1.TestStepsCandidateWithoutAs, "a decode candidate without an encoding",
+           "has a decode candidate without an as"},
+          {Acme.Test.V1.TestStepsEmptyTrimChars, "an empty trim chars set", "has a trim step with an empty chars set"},
+          {Acme.Test.V1.TestStepsTrimWithoutBy, "a trim without a by", "has a trim step without a by"},
+          {Acme.Test.V1.TestStepsStepWithoutOp, "a step without an op", "has a step without an op"},
+          {Acme.Test.V1.TestStepsByteSizeWithoutBound, "a byte_size without a bound", "has a byte_size without a bound"}
+        ] do
+      test "rejects #{description}" do
+        assert_raise CompileError, Regex.compile!(unquote(expected)), fn ->
+          compile_env_module(unquote(message))
+        end
+      end
+    end
+
+    defp compile_env_module(message) do
+      module = Module.concat(__MODULE__, :"Invalid#{System.unique_integer([:positive])}")
+
+      Code.compile_quoted(
+        quote do
+          defmodule unquote(module) do
+            use Trogon.Proto.Env, message: unquote(message)
+          end
+        end
+      )
     end
   end
 end


### PR DESCRIPTION
- A key reaches a service base64 encoded or as raw bytes depending on who provisioned it, and usually carrying the newline a shell left behind. Every service resolving that on its own means every service resolves it differently.
- The declared byte size is what tells those two readings apart, so the contract is the only place able to settle which one is correct.
- Rejecting a value that cannot be read that way belongs at compile time, not at the first boot in production.
- Failure messages have to stay safe to log, which rules out echoing back the value that failed.