### PR TITLE
fix(trogon_proto): reject env fields the loader cannot populate

### DIFF
--- a/apps/trogon_proto/lib/trogon/proto/env.ex
+++ b/apps/trogon_proto/lib/trogon/proto/env.ex
@@ -507,15 +507,13 @@ defmodule Trogon.Proto.Env do
 
     cond do
       is_nil(env_var_option) ->
-        warn_empty_env_var_extension(field_desc)
-        nil
+        raise_field_error!(field_desc.name, "has an env_var extension but env_var is empty")
 
       valid_env_field?(field_type, is_repeated, env_var_option) ->
         {String.to_atom(field_desc.name), build_field_config(field_desc, field_type, env_var_option, is_repeated)}
 
       true ->
-        warn_unsupported_field(field_desc, field_type, is_repeated)
-        nil
+        raise_field_error!(field_desc.name, unsupported_field_reason(field_desc, field_type, is_repeated))
     end
   end
 
@@ -830,18 +828,11 @@ defmodule Trogon.Proto.Env do
     end
   end
 
-  defp warn_empty_env_var_extension(field_desc) do
-    IO.warn(
-      "Field #{field_desc.name} has env_var extension but env_var is empty; skipping.",
-      []
-    )
-  end
-
   defp visibility_value(nil), do: Visibility.value(:VISIBILITY_UNSPECIFIED)
   defp visibility_value(atom) when is_atom(atom), do: Visibility.value(atom)
   defp visibility_value(int) when is_integer(int), do: int
 
-  defp warn_unsupported_field(field_desc, field_type, is_repeated) do
+  defp unsupported_field_reason(field_desc, field_type, is_repeated) do
     label_str =
       case field_desc.label do
         :LABEL_REPEATED -> "repeated "
@@ -849,16 +840,13 @@ defmodule Trogon.Proto.Env do
         _ -> ""
       end
 
-    message =
-      "Field #{field_desc.name} has env_var extension but unsupported type #{label_str}#{inspect(field_type)}. " <>
-        "Only scalar string, bytes, int32, int64, float, double, bool, and enum fields are supported" <>
-        if is_repeated do
-          " (repeated fields require a split step)"
-        else
-          ""
-        end <> "."
-
-    IO.warn(message, [])
+    "has an env_var extension but unsupported type #{label_str}#{inspect(field_type)}; " <>
+      "only scalar string, bytes, int32, int64, float, double, bool, and enum fields are supported" <>
+      if is_repeated do
+        " (repeated fields require a split step)"
+      else
+        ""
+      end
   end
 
   defp has_split_delimiter?(%{split_delimiter: delimiter}) do

--- a/apps/trogon_proto/lib/trogon/proto/env.ex
+++ b/apps/trogon_proto/lib/trogon/proto/env.ex
@@ -110,6 +110,7 @@ defmodule Trogon.Proto.Env do
 
   # Visibility codes - UNSPECIFIED (0) and SECRET (2) are both masked in inspect (secure by default)
   @visibility_plaintext Visibility.value(:VISIBILITY_PLAINTEXT)
+  @visibility_values Enum.map(Visibility.descriptor().value, & &1.number)
 
   # Proto extension and module configuration
   @extension_tag 870_003
@@ -501,11 +502,19 @@ defmodule Trogon.Proto.Env do
   end
 
   defp process_env_var_extension(field_desc, field_prop, binary) do
-    %{env_var: env_var_option} = FieldOptions.decode(binary)
+    field_options = FieldOptions.decode(binary)
+    env_var_option = field_options.env_var
     is_repeated = field_prop.repeated?
     field_type = field_prop.type
 
     cond do
+      unreadable_schema?(field_options) ->
+        raise_field_error!(
+          field_desc.name,
+          "has an env_var annotation written against a newer trogon.env.v1alpha1 than this package supports; " <>
+            "bump the trogon-proto module pin and regenerate"
+        )
+
       is_nil(env_var_option) ->
         raise_field_error!(field_desc.name, "has an env_var extension but env_var is empty")
 
@@ -523,7 +532,7 @@ defmodule Trogon.Proto.Env do
 
     config = %{
       env_var_name: field_name_to_env_var(field_desc.name),
-      visibility: visibility_value(env_var_option.visibility),
+      visibility: visibility_value!(field_desc.name, env_var_option.visibility),
       default_value: default_value,
       field_type: field_type,
       is_repeated: is_repeated,
@@ -828,9 +837,33 @@ defmodule Trogon.Proto.Env do
     end
   end
 
-  defp visibility_value(nil), do: Visibility.value(:VISIBILITY_UNSPECIFIED)
-  defp visibility_value(atom) when is_atom(atom), do: Visibility.value(atom)
-  defp visibility_value(int) when is_integer(int), do: int
+  defp visibility_value!(_field_name, nil), do: Visibility.value(:VISIBILITY_UNSPECIFIED)
+  defp visibility_value!(_field_name, atom) when is_atom(atom), do: Visibility.value(atom)
+  defp visibility_value!(_field_name, int) when int in @visibility_values, do: int
+
+  defp visibility_value!(field_name, int) when is_integer(int) do
+    raise_field_error!(
+      field_name,
+      "has an undeclared visibility #{inspect(int)}; bump the trogon-proto module pin and regenerate"
+    )
+  end
+
+  # Anything the annotation carries that this package's schema does not declare
+  # lands in __unknown_fields__ rather than failing to decode, so a newer
+  # option would otherwise be dropped and its guarantee lost.
+  defp unreadable_schema?(%{__unknown_fields__: unknown}) when unknown != [], do: true
+
+  defp unreadable_schema?(%_{} = message) do
+    message
+    |> Map.from_struct()
+    |> Map.delete(:__unknown_fields__)
+    |> unreadable_schema?()
+  end
+
+  defp unreadable_schema?(%{} = map), do: Enum.any?(map, fn {_key, value} -> unreadable_schema?(value) end)
+  defp unreadable_schema?(list) when is_list(list), do: Enum.any?(list, &unreadable_schema?/1)
+  defp unreadable_schema?(tuple) when is_tuple(tuple), do: tuple |> Tuple.to_list() |> unreadable_schema?()
+  defp unreadable_schema?(_other), do: false
 
   defp unsupported_field_reason(field_desc, field_type, is_repeated) do
     label_str =

--- a/apps/trogon_proto/test/proto/acme/test_unsupported.proto
+++ b/apps/trogon_proto/test/proto/acme/test_unsupported.proto
@@ -4,13 +4,32 @@ package acme.test.v1;
 
 import "trogon/env/v1alpha1/options.proto";
 
-message TestUnsupported {
-  string database_url = 1 [(trogon.env.v1alpha1.field).env_var = {
-    visibility: VISIBILITY_SECRET
-  }];
+// Every message here annotates a field the loader cannot populate. Dropping
+// such a field would leave a zero value in production, so all of them must be
+// rejected at compile time. None has a fixture module for that reason.
 
-  // Unsupported: repeated field without split_delimiter
-  repeated string tags = 2 [(trogon.env.v1alpha1.field).env_var = {
+message TestUnsupportedRepeatedWithoutSplit {
+  repeated string tags = 1 [(trogon.env.v1alpha1.field).env_var = {
     visibility: VISIBILITY_PLAINTEXT
   }];
+}
+
+message TestUnsupportedMessageField {
+  Nested nested = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT
+  }];
+
+  message Nested {
+    string value = 1;
+  }
+}
+
+message TestUnsupportedMapField {
+  map<string, string> labels = 1 [(trogon.env.v1alpha1.field).env_var = {
+    visibility: VISIBILITY_PLAINTEXT
+  }];
+}
+
+message TestUnsupportedEmptyEnvVar {
+  string database_url = 1 [(trogon.env.v1alpha1.field) = {}];
 }

--- a/apps/trogon_proto/test/support/env/config_with_unsupported.ex
+++ b/apps/trogon_proto/test/support/env/config_with_unsupported.ex
@@ -1,3 +1,0 @@
-defmodule Trogon.Proto.TestSupport.ConfigWithUnsupported do
-  use Trogon.Proto.Env, message: Acme.Test.V1.TestUnsupported
-end

--- a/apps/trogon_proto/test/support/env/future_schema.ex
+++ b/apps/trogon_proto/test/support/env/future_schema.ex
@@ -1,0 +1,114 @@
+defmodule Trogon.Proto.TestSupport.FutureSchema do
+  @moduledoc """
+  Message doubles that stand in for annotations written against a newer
+  `trogon.env.v1alpha1` than this package is generated from.
+
+  buf cannot produce such a fixture, because the test protos import the very
+  `options.proto` the package is generated from, so the annotation bytes are
+  assembled by hand here.
+  """
+
+  alias Google.Protobuf.DescriptorProto
+  alias Google.Protobuf.FieldDescriptorProto
+  alias Google.Protobuf.FieldOptions
+  alias TrogonProto.Env.V1Alpha1.EnvVarOption
+
+  @extension_tag 870_003
+
+  # Field 9, varint wire type, value 1. No release of trogon.env.v1alpha1
+  # assigns it, so a decoder generated from this schema preserves it as an
+  # unknown field instead of reading it.
+  @future_field <<72, 1>>
+
+  def descriptor(name, extension_binary) do
+    %DescriptorProto{
+      name: name,
+      field: [
+        %FieldDescriptorProto{
+          name: "database_url",
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          json_name: "databaseUrl",
+          options: %FieldOptions{__unknown_fields__: [{@extension_tag, 2, extension_binary}]}
+        }
+      ]
+    }
+  end
+
+  def message_props do
+    %{field_props: %{1 => %{repeated?: false, type: :string}}}
+  end
+
+  def supported_annotation do
+    embed_env_var(EnvVarOption.encode(%EnvVarOption{visibility: :VISIBILITY_PLAINTEXT}))
+  end
+
+  def annotation_with_future_option do
+    supported_annotation() <> @future_field
+  end
+
+  def annotation_with_future_env_var_option do
+    embed_env_var(EnvVarOption.encode(%EnvVarOption{visibility: :VISIBILITY_PLAINTEXT}) <> @future_field)
+  end
+
+  def annotation_with_future_visibility do
+    embed_env_var(<<8, 7>>)
+  end
+
+  defp embed_env_var(binary), do: <<10, byte_size(binary)>> <> binary
+end
+
+defmodule Trogon.Proto.TestSupport.FutureSchema.SupportedAnnotation do
+  @moduledoc false
+
+  alias Trogon.Proto.TestSupport.FutureSchema
+
+  defstruct [:database_url]
+
+  @type t :: %__MODULE__{database_url: String.t() | nil}
+
+  def descriptor, do: FutureSchema.descriptor("SupportedAnnotation", FutureSchema.supported_annotation())
+  def __message_props__, do: FutureSchema.message_props()
+end
+
+defmodule Trogon.Proto.TestSupport.FutureSchema.FutureOption do
+  @moduledoc false
+
+  alias Trogon.Proto.TestSupport.FutureSchema
+
+  defstruct [:database_url]
+
+  @type t :: %__MODULE__{database_url: String.t() | nil}
+
+  def descriptor, do: FutureSchema.descriptor("FutureOption", FutureSchema.annotation_with_future_option())
+  def __message_props__, do: FutureSchema.message_props()
+end
+
+defmodule Trogon.Proto.TestSupport.FutureSchema.FutureEnvVarOption do
+  @moduledoc false
+
+  alias Trogon.Proto.TestSupport.FutureSchema
+
+  defstruct [:database_url]
+
+  @type t :: %__MODULE__{database_url: String.t() | nil}
+
+  def descriptor,
+    do: FutureSchema.descriptor("FutureEnvVarOption", FutureSchema.annotation_with_future_env_var_option())
+
+  def __message_props__, do: FutureSchema.message_props()
+end
+
+defmodule Trogon.Proto.TestSupport.FutureSchema.FutureVisibility do
+  @moduledoc false
+
+  alias Trogon.Proto.TestSupport.FutureSchema
+
+  defstruct [:database_url]
+
+  @type t :: %__MODULE__{database_url: String.t() | nil}
+
+  def descriptor, do: FutureSchema.descriptor("FutureVisibility", FutureSchema.annotation_with_future_visibility())
+  def __message_props__, do: FutureSchema.message_props()
+end

--- a/apps/trogon_proto/test/support/proto/acme/test_unsupported.pb.ex
+++ b/apps/trogon_proto/test/support/proto/acme/test_unsupported.pb.ex
@@ -1,51 +1,20 @@
-defmodule Acme.Test.V1.TestUnsupported do
+defmodule Acme.Test.V1.TestUnsupportedRepeatedWithoutSplit do
   @moduledoc false
 
   use Protobuf,
-    full_name: "acme.test.v1.TestUnsupported",
+    full_name: "acme.test.v1.TestUnsupportedRepeatedWithoutSplit",
     protoc_gen_elixir_version: "0.16.0",
     syntax: :proto3
 
   def descriptor do
     # credo:disable-for-next-line
     %Google.Protobuf.DescriptorProto{
-      name: "TestUnsupported",
+      name: "TestUnsupportedRepeatedWithoutSplit",
       field: [
-        %Google.Protobuf.FieldDescriptorProto{
-          name: "database_url",
-          extendee: nil,
-          number: 1,
-          label: :LABEL_OPTIONAL,
-          type: :TYPE_STRING,
-          type_name: nil,
-          default_value: nil,
-          options: %Google.Protobuf.FieldOptions{
-            ctype: :STRING,
-            packed: nil,
-            deprecated: false,
-            lazy: false,
-            jstype: :JS_NORMAL,
-            weak: false,
-            unverified_lazy: false,
-            debug_redact: false,
-            retention: nil,
-            targets: [],
-            edition_defaults: [],
-            features: nil,
-            feature_support: nil,
-            uninterpreted_option: [],
-            __pb_extensions__: %{},
-            __unknown_fields__: [{870_003, 2, <<10, 2, 8, 2>>}]
-          },
-          oneof_index: nil,
-          json_name: "databaseUrl",
-          proto3_optional: nil,
-          __unknown_fields__: []
-        },
         %Google.Protobuf.FieldDescriptorProto{
           name: "tags",
           extendee: nil,
-          number: 2,
+          number: 1,
           label: :LABEL_REPEATED,
           type: :TYPE_STRING,
           type_name: nil,
@@ -86,6 +55,384 @@ defmodule Acme.Test.V1.TestUnsupported do
     }
   end
 
+  field(:tags, 1, repeated: true, type: :string, deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestUnsupportedMessageField.Nested do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestUnsupportedMessageField.Nested",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Nested",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "value",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "value",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:value, 1, type: :string)
+end
+
+defmodule Acme.Test.V1.TestUnsupportedMessageField do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestUnsupportedMessageField",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestUnsupportedMessageField",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "nested",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_MESSAGE,
+          type_name: ".acme.test.v1.TestUnsupportedMessageField.Nested",
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [{870_003, 2, <<10, 2, 8, 1>>}]
+          },
+          oneof_index: nil,
+          json_name: "nested",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [
+        %Google.Protobuf.DescriptorProto{
+          name: "Nested",
+          field: [
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "value",
+              extendee: nil,
+              number: 1,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_STRING,
+              type_name: nil,
+              default_value: nil,
+              options: nil,
+              oneof_index: nil,
+              json_name: "value",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            }
+          ],
+          nested_type: [],
+          enum_type: [],
+          extension_range: [],
+          extension: [],
+          options: nil,
+          oneof_decl: [],
+          reserved_range: [],
+          reserved_name: [],
+          __unknown_fields__: []
+        }
+      ],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:nested, 1, type: Acme.Test.V1.TestUnsupportedMessageField.Nested, deprecated: false)
+end
+
+defmodule Acme.Test.V1.TestUnsupportedMapField.LabelsEntry do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestUnsupportedMapField.LabelsEntry",
+    map: true,
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "LabelsEntry",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "key",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "key",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "value",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "value",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: %Google.Protobuf.MessageOptions{
+        message_set_wire_format: false,
+        no_standard_descriptor_accessor: false,
+        deprecated: false,
+        map_entry: true,
+        deprecated_legacy_json_field_conflicts: nil,
+        features: nil,
+        uninterpreted_option: [],
+        __pb_extensions__: %{},
+        __unknown_fields__: []
+      },
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:key, 1, type: :string)
+  field(:value, 2, type: :string)
+end
+
+defmodule Acme.Test.V1.TestUnsupportedMapField do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestUnsupportedMapField",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestUnsupportedMapField",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "labels",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_REPEATED,
+          type: :TYPE_MESSAGE,
+          type_name: ".acme.test.v1.TestUnsupportedMapField.LabelsEntry",
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [{870_003, 2, <<10, 2, 8, 1>>}]
+          },
+          oneof_index: nil,
+          json_name: "labels",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [
+        %Google.Protobuf.DescriptorProto{
+          name: "LabelsEntry",
+          field: [
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "key",
+              extendee: nil,
+              number: 1,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_STRING,
+              type_name: nil,
+              default_value: nil,
+              options: nil,
+              oneof_index: nil,
+              json_name: "key",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            },
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "value",
+              extendee: nil,
+              number: 2,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_STRING,
+              type_name: nil,
+              default_value: nil,
+              options: nil,
+              oneof_index: nil,
+              json_name: "value",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            }
+          ],
+          nested_type: [],
+          enum_type: [],
+          extension_range: [],
+          extension: [],
+          options: %Google.Protobuf.MessageOptions{
+            message_set_wire_format: false,
+            no_standard_descriptor_accessor: false,
+            deprecated: false,
+            map_entry: true,
+            deprecated_legacy_json_field_conflicts: nil,
+            features: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: []
+          },
+          oneof_decl: [],
+          reserved_range: [],
+          reserved_name: [],
+          __unknown_fields__: []
+        }
+      ],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
+  field(:labels, 1,
+    repeated: true,
+    type: Acme.Test.V1.TestUnsupportedMapField.LabelsEntry,
+    map: true,
+    deprecated: false
+  )
+end
+
+defmodule Acme.Test.V1.TestUnsupportedEmptyEnvVar do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "acme.test.v1.TestUnsupportedEmptyEnvVar",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "TestUnsupportedEmptyEnvVar",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "database_url",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: %Google.Protobuf.FieldOptions{
+            ctype: :STRING,
+            packed: nil,
+            deprecated: false,
+            lazy: false,
+            jstype: :JS_NORMAL,
+            weak: false,
+            unverified_lazy: false,
+            debug_redact: false,
+            retention: nil,
+            targets: [],
+            edition_defaults: [],
+            features: nil,
+            feature_support: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: [{870_003, 2, ""}]
+          },
+          oneof_index: nil,
+          json_name: "databaseUrl",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
+
   field(:database_url, 1, type: :string, json_name: "databaseUrl", deprecated: false)
-  field(:tags, 2, repeated: true, type: :string, deprecated: false)
 end

--- a/apps/trogon_proto/test/trogon/proto/env_test.exs
+++ b/apps/trogon_proto/test/trogon/proto/env_test.exs
@@ -11,7 +11,6 @@ defmodule Trogon.Proto.EnvTest do
   alias Trogon.Proto.TestSupport.ConfigWithStepsUrlSafe
   alias Trogon.Proto.TestSupport.ConfigWithTrimCustom
   alias Trogon.Proto.TestSupport.ConfigWithTrimUnicode
-  alias Trogon.Proto.TestSupport.ConfigWithUnsupported
 
   setup {Mox, :set_mox_from_context}
 
@@ -538,21 +537,19 @@ defmodule Trogon.Proto.EnvTest do
   end
 
   describe "unsupported field types" do
-    test "repeated fields are skipped (not added to struct)" do
-      # ConfigWithUnsupported has database_url (supported) and tags (unsupported repeated)
-      # Only database_url should be included in the config
-      TestSupport.stub_system_env(%{
-        "DATABASE_URL" => "postgres://localhost"
-      })
-
-      # Load should work because only database_url is required
-      config = ConfigWithUnsupported.from_env!()
-
-      # database_url should exist
-      assert config.env.database_url == "postgres://localhost"
-
-      # tags was not loaded from env (unsupported repeated without split_delimiter), so default []
-      assert config.env.tags == []
+    for {message, description, expected} <- [
+          {Acme.Test.V1.TestUnsupportedRepeatedWithoutSplit, "a repeated field that never splits",
+           "unsupported type repeated :string.*repeated fields require a split step"},
+          {Acme.Test.V1.TestUnsupportedMessageField, "a message field", "unsupported type"},
+          {Acme.Test.V1.TestUnsupportedMapField, "a map field", "unsupported type"},
+          {Acme.Test.V1.TestUnsupportedEmptyEnvVar, "an extension with no env_var",
+           "has an env_var extension but env_var is empty"}
+        ] do
+      test "rejects #{description}" do
+        assert_raise CompileError, Regex.compile!(unquote(expected)), fn ->
+          compile_env_module(unquote(message))
+        end
+      end
     end
   end
 
@@ -941,17 +938,17 @@ defmodule Trogon.Proto.EnvTest do
         end
       end
     end
+  end
 
-    defp compile_env_module(message) do
-      module = Module.concat(__MODULE__, :"Invalid#{System.unique_integer([:positive])}")
+  defp compile_env_module(message) do
+    module = Module.concat(__MODULE__, :"Invalid#{System.unique_integer([:positive])}")
 
-      Code.compile_quoted(
-        quote do
-          defmodule unquote(module) do
-            use Trogon.Proto.Env, message: unquote(message)
-          end
+    Code.compile_quoted(
+      quote do
+        defmodule unquote(module) do
+          use Trogon.Proto.Env, message: unquote(message)
         end
-      )
-    end
+      end
+    )
   end
 end

--- a/apps/trogon_proto/test/trogon/proto/env_test.exs
+++ b/apps/trogon_proto/test/trogon/proto/env_test.exs
@@ -11,6 +11,7 @@ defmodule Trogon.Proto.EnvTest do
   alias Trogon.Proto.TestSupport.ConfigWithStepsUrlSafe
   alias Trogon.Proto.TestSupport.ConfigWithTrimCustom
   alias Trogon.Proto.TestSupport.ConfigWithTrimUnicode
+  alias Trogon.Proto.TestSupport.FutureSchema
 
   setup {Mox, :set_mox_from_context}
 
@@ -931,6 +932,28 @@ defmodule Trogon.Proto.EnvTest do
           {Acme.Test.V1.TestStepsTrimWithoutBy, "a trim without a by", "has a trim step without a by"},
           {Acme.Test.V1.TestStepsStepWithoutOp, "a step without an op", "has a step without an op"},
           {Acme.Test.V1.TestStepsByteSizeWithoutBound, "a byte_size without a bound", "has a byte_size without a bound"}
+        ] do
+      test "rejects #{description}" do
+        assert_raise CompileError, Regex.compile!(unquote(expected)), fn ->
+          compile_env_module(unquote(message))
+        end
+      end
+    end
+  end
+
+  describe "annotations from a newer schema" do
+    test "accepts the double that only uses options this package declares" do
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        assert [{_module, _bytecode} | _] = compile_env_module(FutureSchema.SupportedAnnotation)
+      end)
+    end
+
+    for {message, description, expected} <- [
+          {FutureSchema.FutureOption, "an undeclared field option",
+           "written against a newer trogon.env.v1alpha1 than this package supports"},
+          {FutureSchema.FutureEnvVarOption, "an undeclared env_var option",
+           "written against a newer trogon.env.v1alpha1 than this package supports"},
+          {FutureSchema.FutureVisibility, "an undeclared visibility", "has an undeclared visibility 7"}
         ] do
       test "rejects #{description}" do
         assert_raise CompileError, Regex.compile!(unquote(expected)), fn ->


### PR DESCRIPTION
- A field annotated for the environment but impossible to read was dropped with only a compile warning. The struct then booted with a zero value, which is indistinguishable from someone having configured it that way on purpose.
- That turns a schema mistake into falsy behavior discovered in production, which is the outcome the annotation exists to prevent. An empty binary passes a presence check and an empty list passes an iteration.
- A compile warning is not a control: it scrolls past in CI output and nothing downstream fails on it.
- An extension declared with no `env_var` had the same shape of silence and is now rejected on the same grounds.
- Version skew was the same hole with a different cause. An annotation written against a newer schema decodes without error here, because anything undeclared is preserved as an unknown field, so a constraint asked for in the proto was simply never enforced and the field loaded as if nothing had been asked of it. The same reasoning applies to an enum value this package does not know.
- Nothing that worked stops working. A field on any of these paths was never populated as the schema asked, so only a schema that was already silently broken now fails to compile.